### PR TITLE
Transfer legacy content and implement single reference file

### DIFF
--- a/source/develop-locally/test-service-provider/use-compliance-tool/generate-selef-signed-certificates/index.html.md.erb
+++ b/source/develop-locally/test-service-provider/use-compliance-tool/generate-selef-signed-certificates/index.html.md.erb
@@ -1,0 +1,49 @@
+---
+title: Generate self-signed certificates
+weight: 10
+---
+
+# Generate self-signed certificates
+
+
+To communicate with GOV.UK Verify you need to use keys and certificates. To communicate with the compliance tool, generate self-signed certificates as described here.
+
+## Generate self-signed certificates with OpenSSL
+
+
+You can generate keys and self-signed certificates in whatever way is most convenient and familiar for you. There are many different formats of keys and certificates. The Matching Service Adapter (MSA) uses PKCS#8 formatted keys (.pk8) and PEM encoded X509 certificates (.crt).
+
+The GOV.UK Verify team generally use the OpenSSL tool to do this using the guidance from the [Heroku Dev Center](https://devcenter.heroku.com/articles/ssl-certificate-self#prerequisites).
+
+
+Install OpenSSL if it isn't already installed:
+
+* OS X (with homebrew) - `brew install openssl`
+* Windows - download the 'Complete package, except sources' from http://gnuwin32.sourceforge.net/packages/openssl.htm
+* Ubuntu Linux - `apt-get install openssl`
+
+Run the following commands in order, replacing:
+
+* `$name` with the filename of the key or certificate you're generating - see [Keys and certificates for your MSA](LINK)
+and [Keys and certificates for your service](LINK)
+* `$commonName` with a description of how the certificate will be used - for example 'My Service MSA Signing Primary'
+
+```sh
+# Generate a private key:
+openssl genrsa -des3 -passout pass:x -out "$name.pass.key" 2048
+openssl rsa -passin pass:x -in "$name.pass.key" -out "$name.key"
+
+# Generate a certificate signing request (CSR):
+openssl req -batch -new -subj "/CN=$commonName" -key "$name.key" -out "$name.csr"
+
+# Generate a self signed certificate:
+openssl x509 -req -sha256 -in "$name.csr" -signkey "$name.key" -out "$name.crt"
+
+# Convert the private key to .pk8 format:
+openssl pkcs8 -topk8 -inform PEM -outform DER -in "$name.key" -out "$name.pk8" -nocrypt
+
+# Clean up the files you don’t need anymore:
+rm "$name.pass.key"
+rm "$name.csr"
+rm "$name.key"
+```

--- a/source/legacy/build-ms/create-datasources/index.html.md.erb
+++ b/source/legacy/build-ms/create-datasources/index.html.md.erb
@@ -1,6 +1,0 @@
----
-title: Title
-weight: 30
----
-
-# Title

--- a/source/legacy/build-ms/create-datasources/index.html.md.erb
+++ b/source/legacy/build-ms/create-datasources/index.html.md.erb
@@ -1,0 +1,6 @@
+---
+title: Title
+weight: 30
+---
+
+# Title

--- a/source/legacy/build-ms/index.html.md.erb
+++ b/source/legacy/build-ms/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Building a matching service
-weight: 30
+weight: 10
 ---
 
 # Building a matching service
@@ -11,3 +11,22 @@ A matching service is is made up of:
 * Local Matching Service built by you
 
 You must host both the MSA and the Local Matching Service on your own infrastructure.
+
+## How matching works with GOV.UK Verify
+
+**figure arch_overview.svg**
+
+When an identity provider has verified a user’s identity, it generates and sends some limited information about that user’s identity to the service via the Verify Hub.
+
+The GOV.UK Verify Hub sends the information, in SAML, to your service where the [Matching Service Adapter (MSA) ](LINK) validates the authenticity of the SAML message and converts it into JSON data.
+
+The MSA then sends the JSON to your [Local Matching Service ](LINK).
+
+The Local Matching Service runs a series of checks to find a possible match in your local datastore(s) and will return:
+
+- no unique match (no match at all or more than one match)
+- unique match with one record
+
+Your [matching strategy ](LINK) should define what your service should do for each outcome.
+
+You must host both the MSA and the Local Matching Service. Together they are known as a ‘matching service’.

--- a/source/legacy/build-ms/index.html.md.erb
+++ b/source/legacy/build-ms/index.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: Building a matching service
+weight: 30
+---
+
+# Building a matching service
+
+A matching service is is made up of:
+
+* Matching Service Adapter (MSA) provided by GOV.UK Verify
+* Local Matching Service built by you
+
+You must host both the MSA and the Local Matching Service on your own infrastructure.

--- a/source/legacy/build-ms/lms/index.html.md.erb
+++ b/source/legacy/build-ms/lms/index.html.md.erb
@@ -1,0 +1,16 @@
+---
+title: Local Matching Service
+weight: 20
+---
+
+# Local Matching Service
+
+A Local Matching Service helps you to find a match between a user’s verified identity and a record in your existing database(s). You must build your own Local Matching Service and host it on your own infrastructure.
+
+As well as following this guidance, you can refer to the [example Local Matching Service built by the GOV.UK Verify team](LINK). It uses a [simplified version of a matching strategy from the Department of Work and Pensions (DWP)](LINK).
+
+You can also use a [matching service test tool built by the GOV.UK Verify team](LINK) to make sure your Local Matching Service can:
+
+- handle matching datasets
+- find and match records correctly
+- handle matching failures

--- a/source/legacy/build-ms/msa/configure-your-msa/index.html.md.erb
+++ b/source/legacy/build-ms/msa/configure-your-msa/index.html.md.erb
@@ -1,0 +1,191 @@
+---
+title: Configure your MSA
+weight: 30
+---
+
+# Configure your MSA
+
+
+Below is the `test-config.yml` file:
+
+```yaml
+# Configure the matching service adapter's server settings here.
+server:
+  # Ports on which to listen for normal connections.
+  # See http://www.dropwizard.io for information on HTTPS and TLS connections.
+  applicationConnectors:
+    - type: http
+      port: 8080
+  # Ports on which to listen for admin tasks.
+  # This can probably be set to the above port+1.
+  adminConnectors:
+    - type: http
+      port: 8081
+
+# Add information about your matching service adapter (MSA) here.
+matchingServiceAdapter:
+  # The entityId is used for SAML communication with Verify.
+  entityId: my-entity-id
+  # The externalUrl is the internet-facing URL for your MSA.
+  externalUrl: http://service.gov.uk/matching-service/POST
+
+# Configure the URLs for your local matching service here.
+localMatchingService:
+  # The matchUrl is where the MSA should post user attributes on a successful match
+  matchUrl: http://service.gov.uk/local-matching/match
+  # The accountCreationUrl is where the MSA should post attributes for unknown users
+  accountCreationUrl: http://service.gov.uk/local-matching/create-account
+
+# Configure the key pairs used by your MSA for signing SAML messages here.
+signingKeys:
+  # The primary signing key is used to sign all messages to Verify.
+  primary:
+    publicKey:
+      # The certificate (.crt) containing the primary public signing key:
+      certFile: test_primary_signing.crt
+      # The common name (CN) of that certificate:
+      name: Test MSA Signing
+    privateKey:
+      # The PK8 (.pk8) containing the primary private signing key:
+      keyFile: test_primary_signing.pk8
+  # The public part of the secondary signing key is published in the MSA's metadata
+  # during key rollovers but is otherwise unused by the MSA.
+  secondary:
+    publicKey:
+      certFile: test_secondary_signing.crt
+      name: Test Another MSA Signing
+    privateKey:
+      keyFile: test_secondary_signing.pk8
+
+# Configure the key pairs used by your MSA for encrypting and decrypting SAML
+# messages here. You can configure up to 2 encryption keys at a time and the MSA
+# will attempt decryption with both. Only the first key will be used for encryption.
+encryptionKeys:
+  - publicKey:
+      certFile: test_msa_encryption_1.crt
+      name: Test MSA Encryption 1
+    privateKey:
+      keyFile: test_msa_encryption_1.pk8
+  - publicKey:
+      certFile: test_msa_encryption_2.crt
+      name: Test MSA Encryption 2
+    privateKey:
+      keyFile: test_msa_encryption_2.pk8
+
+# Settings for connecting with the hub can be configured here
+# if necessary.
+hub:
+  ssoUrl: https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/SSO
+
+# Settings for obtaining Verify's metadata can be configured here.
+metadata:
+  environment: INTEGRATION
+  url: https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/SAML2/metadata/federation
+  trustStore:
+    path: test_ida_metadata.ts
+    password: puppet
+# To override the `hub` and `idp` trust stores, i.e. for testing or manual modifications,
+# you can extract them from the MSA JAR file to a local disk, modify them, and then un-comment the following section:
+  # hubTrustStore:
+    # path: test_hub.ts
+    # password: puppet
+  # idpTrustStore:
+    # path: test_idp.ts
+    # password: puppet
+
+# This is a required section if your service needs to consume European identities.
+europeanIdentity:
+  enabled: ${EUROPEAN_IDENTITY_ENABLED} # true or false
+  hubConnectorEntityId: https://www.integration.signin.service.gov.uk/SAML2/metadata/connector # The URL of the metadata for the node that requests and receives identities from European countries.
+  # Configure metadata for European countries.
+  aggregatedMetadata:
+    trustAnchorUri: https://www.integration.signin.service.gov.uk/SAML2/metadata/trust-anchor # The location of the trust anchor used to validate country metadata
+    metadataSourceUri: https://www.integration.signin.service.gov.uk/SAML2/metadata/aggregator # The location of the aggregated country metadata
+    trustStore: # The location and password for the truststore
+      path: test_ida_metadata.ts
+      password: puppet
+
+## Options to add additional logging. By default, logs will be output to console.
+## See http://www.dropwizard.io for more information.
+#logging:
+#  level: INFO
+#  appenders:
+#    - type: file
+#      currentLogFilename: apps-home/test-rp-msa.log
+#      archivedLogFilenamePattern: apps-home/test-rp-msa.log.%d.gz
+#      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
+#    - type: console
+#      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
+#
+#
+## By default the MSA signs messages using SHA-256.
+## Switch the flag below to `true` if you need to revert to SHA-1 signing:
+#shouldSignWithSHA1: false
+```
+
+## Adapt your configuration file
+
+Make the following changes to the YAML configuration file according to the environment where you want to use the MSA. Variations are indicated for the SAML compliance tool and integration and production environments.
+
+### `server`
+
+Enter port numbers for the server application (`applicationConnectors`) and admin ports (`adminConnectors`).
+
+If the MSA will be handling SSL termination (typically this will be handled by a proxy or load balancer like HAProxy), or if you don't trust the network between the SSL termination endpoint and the MSA, then specify `https` rather than `http` for the type of connection. For more information, see the guidance in the [DropWizard configuration manual](http://dropwizard.github.io/).
+
+### `matchingServiceAdapter`
+
+Enter the entityID for the MSA in `entityId`. This should reflect the name of your service, for example `https://<service name>/MSA`. It's good practice to use the MSA's URI (where the hub will send matching requests) as its entityID, but this isn't mandatory.
+
+Enter the URI for your MSA in `externalUrl`.
+
+### `localMatchingService`
+
+Enter the URI for your local matching service in `matchUrl`.
+
+If you're creating new user accounts when a match isn't found (see [create new user accounts](LINK)), enter the user account creation URI in `accountCreationUrl`.
+
+### `signingKeys`
+
+Enter the paths of the primary SAML signing keys and certificates for your MSA in `primary`.
+
+For the compliance tool, [generate self-signed certificates](LINK).
+
+You'll use different keys and certificates for the integration and production environments - see [pkiRequestCert](LINK).
+
+To convert a private key to PKCS#8 DER format, run the following command:
+
+```
+openssl pkcs8 -topk8 -nocrypt -in server.key -out server.pk8 -outform DER
+```
+
+### `encryptionKeys`
+
+Enter the paths and names of the encryption keys and certificates for your MSA in `encryptionKeys`.  The names are used to identify the certificates in the metadata so should be meaningful and unique, for example, `signing_1` and `encryption_1`.
+
+### `metadata`
+
+Edit the `url` value and specify the location where the MSA accesses the SAML metadata:
+
+  * for the SAML compliance tool, use the default setting in the `test-config.yml` file
+
+  * for the integration environment, enter: `https://www.integration.signin.service.gov.uk/SAML2/metadata/federation` in the `test-config.yml` file
+
+  * for the production environment, use the default setting in the `prod-config.yml` file
+
+In `trustStore.path`, specify the path to your metadata truststore file for the appropriate environment:
+
+    * for the SAML compliance tool and the integration environment, use the provided `test_ida_metadata.ts` file (this is the default setting in the `test-config.yml` file)
+
+    * for the production environment, use the provided `prod_ida_metadata.ts` file (this is the default setting in the `prod-config.yml` file)
+
+Optionally, if you need to override the `hub` and `idp` truststore path for testing in Integration, uncomment the `hubTrustStore` and `idpTrustStore` sections in `test-config.yml`.
+
+### `europeanIdentity`
+
+Configure according to the needs of your service.
+
+If your service needs to consume European identities, set `enabled: true`.
+You also need to configure the URLs for the environments you want to use, for example integration or production. Enabling your service to consume European identities also implies that it will be using [the universal JSON matching schema](LINK). The schema will apply to datasets from both European countries, as well as GOV.UK Verify identity providers.
+
+If if you need to disable European identities, set `enabled: false` in this section. This setting also implies your MSA will be using [the legacy JSON matching schema](LINK).

--- a/source/legacy/build-ms/msa/configure-your-msa/index.html.md.erb
+++ b/source/legacy/build-ms/msa/configure-your-msa/index.html.md.erb
@@ -175,9 +175,9 @@ Edit the `url` value and specify the location where the MSA accesses the SAML me
 
 In `trustStore.path`, specify the path to your metadata truststore file for the appropriate environment:
 
-    * for the SAML compliance tool and the integration environment, use the provided `test_ida_metadata.ts` file (this is the default setting in the `test-config.yml` file)
+  * for the SAML compliance tool and the integration environment, use the provided `test_ida_metadata.ts` file (this is the default setting in the `test-config.yml` file)
 
-    * for the production environment, use the provided `prod_ida_metadata.ts` file (this is the default setting in the `prod-config.yml` file)
+  * for the production environment, use the provided `prod_ida_metadata.ts` file (this is the default setting in the `prod-config.yml` file)
 
 Optionally, if you need to override the `hub` and `idp` truststore path for testing in Integration, uncomment the `hubTrustStore` and `idpTrustStore` sections in `test-config.yml`.
 

--- a/source/legacy/build-ms/msa/connect-service-to-msa/index.html.md.erb
+++ b/source/legacy/build-ms/msa/connect-service-to-msa/index.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Connect your service provider to the MSA metadata
+title: Connect to the MSA metadata
 weight: 30
 ---
 
-# Connect your service provider to the MSA metadata
+# Connect to the MSA metadata
 
-To integrate GOV.UK Verify into your service, you need to connect your service to the Matching Service Adapter (MSA) metadata.
+To integrate GOV.UK Verify into your service, you need to connect your service provider to the Matching Service Adapter (MSA) metadata.
 
 
 The MSA metadata:

--- a/source/legacy/build-ms/msa/connect-service-to-msa/index.html.md.erb
+++ b/source/legacy/build-ms/msa/connect-service-to-msa/index.html.md.erb
@@ -1,0 +1,22 @@
+---
+title: Connect your service provider to the MSA metadata
+weight: 30
+---
+
+# Connect your service provider to the MSA metadata
+
+To integrate GOV.UK Verify into your service, you need to connect your service to the Matching Service Adapter (MSA) metadata.
+
+
+The MSA metadata:
+
+* indicates the URL where your service will send users with their authentication requests - this is the GOV.UK Verify hub
+
+* lists one or more MSA signing certificates, so your service can validate messages that are sent by your MSA
+
+* describes the MSA as an identity provider
+
+
+The MSA metadata is located in your MSA at `/matching-service/SAML2/metadata`
+
+Your service must poll the MSA metadata every 10 minutes.

--- a/source/legacy/build-ms/msa/generate-certificates/index.html.md.erb
+++ b/source/legacy/build-ms/msa/generate-certificates/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: Keys and certificates for your MSA
+title: Keys and certificates
 weight: 40
 ---
 
-# Keys and certificates for your MSA
+# Keys and certificates
 
 With the default configuration in `test-config.yml` the MSA needs the following keys and certificates:
 

--- a/source/legacy/build-ms/msa/generate-certificates/index.html.md.erb
+++ b/source/legacy/build-ms/msa/generate-certificates/index.html.md.erb
@@ -1,0 +1,15 @@
+---
+title: Keys and certificates for your MSA
+weight: 40
+---
+
+# Keys and certificates for your MSA
+
+With the default configuration in `test-config.yml` the MSA needs the following keys and certificates:
+
+* `test_primary_signing{.pk8,.crt}` - primary signing private key and certificate
+* `test_secondary_signing{.pk8,.crt}` - secondary signing private key and certificate
+* `test_msa_encryption_1{.pk8,.crt}` - primary encryption private key and certificate
+* `test_msa_encryption_2{.pk8,.crt}` - secondary encryption private key and certificate
+
+The MSA needs primary and secondary keys to support [key rotations](LINK) without causing service downtime for users.

--- a/source/legacy/build-ms/msa/handle-saml-responses/index.html.md.erb
+++ b/source/legacy/build-ms/msa/handle-saml-responses/index.html.md.erb
@@ -3,9 +3,9 @@ title: Handle SAML responses
 weight: 50
 ---
 
-# Handle SAML responses using SAML metadata
+# Handle SAML responses
 
-
+You can handle SAML responses using SAML metadata.
 To consume SAML responses that are issued by the GOV.UK Verify hub:
 
 1. Decrypt the assertion.

--- a/source/legacy/build-ms/msa/handle-saml-responses/index.html.md.erb
+++ b/source/legacy/build-ms/msa/handle-saml-responses/index.html.md.erb
@@ -1,0 +1,17 @@
+---
+title: Handle SAML responses
+weight: 50
+---
+
+# Handle SAML responses using SAML metadata
+
+
+To consume SAML responses that are issued by the GOV.UK Verify hub:
+
+1. Decrypt the assertion.
+
+2. Validate the signature on the assertion contained in the response. This assertion is generated and signed by your MSA.
+
+   You can use the X509 signing certificate contained in the MSA metadata to validate this signature.
+
+Use this procedure with care. You must trust assertions signed by the MSA only. The GOV.UK Verify hub never issues assertions for consumption by the service endpoint, so make sure that it’s **not** possible to trust the hub to issue assertions.

--- a/source/legacy/build-ms/msa/index.html.md.erb
+++ b/source/legacy/build-ms/msa/index.html.md.erb
@@ -1,0 +1,129 @@
+---
+title: Matching Service Adapter
+weight: 10
+---
+
+# Matching Service Adapter
+
+The Matching Service Adapter (MSA) is a software tool supplied free of charge by the GOV.UK Verify team. It simplifies communication between your Local Matching Service and the GOV.UK Verify Hub.
+
+## Set up your MSA
+
+The Matching Service Adapter (MSA) is a software tool supplied free of charge by the GOV.UK Verify team. It simplifies communication between your Local Matching Service and the GOV.UK Verify Hub.
+
+The MSA handles complex matching requirements. We recommend that you use the MSA and always make sure you have the latest version.
+
+You need to host the MSA so the GOV.UK Verify Hub can make requests to it.
+
+If you do not want to use the MSA, [contact the GOV.UK Verify team](LINK).
+
+To run the Matching Service Adapter (MSA) you need:
+
+* Java Runtime Environment (JRE) version 8
+* 512 MB to 1 GB of RAM, on top of what you need to run your operating system
+
+1. [Download the latest release of the MSA](https://github.com/alphagov/verify-matching-service-adapter/releases/latest). It contains:
+      * a JAR (Java Archive) file containing the MSA implementation, as well as the trust stores `prod_ida_idp_metadata.ts`, `prod_ida_hub_metadata.ts`, `test_ida_idp_metadata.ts`, and `test_ida_hub_metadata.ts`
+      * a truststore metadata file for non-production environments (the SAML compliance tool and the integration environment) - `test_ida_metadata.ts`
+      * a truststore metadata file for the production environment - `prod_ida_metadata.ts`
+      * a sample YAML configuration file for non-production environments  - `test-config.yml`
+      * a sample YAML configuration file for the production environment  - `prod-config.yml`
+
+2. To extract the files, run the following command::
+
+      ```sh
+      unzip verify-matching-service-adapter-[build number].zip
+      ```
+
+### Versioning
+
+Typically, GOV.UK Verify releases a new version of the MSA every 2 or 3 months. Some releases are essential updates and we may remove support for older versions. To keep updated, contact the [GOV.UK Verify support team](mailto:idasupport+onboarding@digital.cabinet-office.gov.uk) to ensure you are on the MSA email distribution list.
+
+## Get certificates for your MSA
+
+Your MSA needs a signing certificate and an encryption certificate. You must use different certificates for each environment.
+
+To obtain certificates:
+
+* [generate self-signed certificates](LINK) for the SAML compliance tool
+* [request certificates](LINK) from the IDAP certificate authority for the integration and production environments
+
+## Configure your MSA
+
+When you [start the MSA](LINK), you need to supply a YAML configuration file.
+
+The MSA zip file contains two sample YAML configuration files:
+
+* `test-config.yml` for the SAML compliance tool and the integration environment
+* `prod-config.yml` for the production environment
+
+[Adapt the YAML configuration file](LINK) where required.
+
+## Start the Matching Service Adapter
+
+To start using the MSA, run the following command, supplying the path to your configuration file:
+
+```sh
+java -jar [filename].jar server [path to configuration file].yml
+```
+You can now run [SAML compliance tests between the hub and your MSA](LINK).
+To help [build your local matching service](LINK),
+you can use the [example of the JSON request](LINK) that the MSA posts to your service.
+
+### Error: Signature verification failed
+
+When starting the MSA, you may receive an error message with the phrase ‘signature verification failed’. This is expected behaviour and is logged from a third-party library.
+
+The Verify hub metadata contains multiple signing certificates, but only one private key is in use at a time. The metadata refreshes automatically approximately every 10 minutes.
+
+The MSA checks each of the certificates in turn. The MSA will return ‘Signature verification failed’ if it checks an unused certificate. It will then continue to check each certificate until it finds a valid certificate.
+
+## Monitoring
+
+When the MSA is installed in your [integration or production environment](LINK), health checks run every 60 seconds to ensure that the MSA is functioning correctly. They test:
+
+* connectivity
+* that the MSA accepts the hub signature
+* that the hub accepts the MSA signature
+
+## Configure HTTP proxies
+
+The MSA supports HTTP and HTTPS proxies configured by Java properties.
+
+For information on configuring HTTPS proxies, refer to the [Java documentation](http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html).
+
+## Secure your MSA
+
+### MSA TLS certificates
+
+The table below shows the root certificate authorities that GOV.UK Verify trusts for HTTPS connections to your matching service in the [integration and production environments](LINK).
+
+| Root certificate authority   | Common name                 | X509v3 subject key identifier                                 |
+| ---                          | ---                         | ---                                                           |
+| AddTrust External CA Root    | AddTrust External CA Root   | AD:BD:98:7A:34:B4:26:F7:FA:C4:26:54:EF:03:BD:E0:24:CB:54:1A   |
+| GeoTrust Global CA           | GeoTrust Global CA          | C0:7A:98:68:8D:89:FB:AB:05:64:0C:11:7D:AA:7D:65:B8:CA:CC:4E   |
+| QuoVadis Root CA 2           | QuoVadis Root CA 2          | 1A:84:62:BC:48:4C:33:25:04:D4:EE:D0:F6:03:C4:19:46:D1:94:6B   |
+
+For the SAML compliance tool, use [self-signed certificates](LINK).
+
+If you want to use a root certificate authority for your matching service that isn’t in the above table, raise a ticket with us by sending an email to `idasupport+onboarding@digital.cabinet-office.gov.uk`. We’ll review your chosen root certificate authority before adding it to this list.
+
+When you raise a ticket, indicate the chain of trust with your SSL/TLS certificate. You'll also need the chain of trust when you configure your server.
+
+### Connect your MSA to the internet securely
+
+Your MSA must only respond to matching requests from the GOV.UK Verify hub, otherwise there’s a risk of user data being compromised.
+
+The MSA checks that matching service requests are genuine by checking their cryptographic signatures.
+
+To ensure that only the GOV.UK Verify hub can access the MSA, make sure your MSA:
+
+* is only exposed as HTTPS endpoints
+* only uses strong recent versions of TLS (for example TLS 1.2); turn off obsolete and insecure versions (for example SSLv1, SSLv2, and SSLv3)
+* supports multiple strong cipher suites
+
+      > GOV.UK Verify will remove support for TLS cipher suites if serious weaknesses become known. Having multiple suites provides resilience.
+
+* allows requests and health checks only from the IP addresses of hub services provided by your engagement lead
+
+      > Each MSA should communicate with only 1 hub service (SAML compliance tool, integration environment, or production environment).

--- a/source/legacy/build-ms/respond-to-matching-requests/index.html.md.erb
+++ b/source/legacy/build-ms/respond-to-matching-requests/index.html.md.erb
@@ -1,0 +1,34 @@
+---
+title: Respond to matching requests
+weight: 30
+---
+
+# Respond to matching requests
+
+Your service must respond to JSON matching requests from the Matching Service Adapter (MSA). The MSA makes requests to the URLs specified in the [YAML configuration file](LINK):
+
+* `localMatchingService:` `matchUrl:`
+* `localMatchingService:` `accountCreationUrl:` (if you're [creating new user accounts](LINK) when a match is not found)
+
+
+The MSA sends one matching request for both Cycle 0 and Cycle 1 to your local matching service. Below is a formatted example for a GOV.UK Verify identity using the [universal JSON schema].
+
+The matching request for a [European identity](LINK), will be formatted according to the [universal JSON schema](LINK). If you haven't enabled European identities in your MSA configuration, the matching request will be formatted using [the legacy JSON schema](LINK).
+
+Your local matching service first runs cycle 0. If no match is found, it runs cycle 1. It then sends either a `match` or a `no-match` response to the MSA. This response corresponds to step 6 in the [SAML message flow](LINK).
+
+Below is a match response (it should have the status code 200 OK):
+
+```sh
+{"result":"match"}
+```
+
+Below is a no-match response (it should have the status code 200 OK):
+
+```sh
+{"result":"no-match"}
+```
+
+If you’re using cycle 3 and your local matching service returned a `no-match` response to the MSA, the MSA sends a cycle 3 matching request. Below is a formatted example for a GOV.UK Verify identity using the [universal JSON schema](LINK).
+
+If no match is found on cycles 0, 1 and 3, you can [create a new account](LINK) for the user.

--- a/source/legacy/build-ms/respond-to-matching-requests/legacy-json-schema/index.html.md.erb
+++ b/source/legacy/build-ms/respond-to-matching-requests/legacy-json-schema/index.html.md.erb
@@ -1,0 +1,186 @@
+---
+title: Legacy JSON schema
+weight: 30
+---
+
+# Legacy JSON schema
+
+If you [configured your MSA](LINK) to not consume EU identities, the matching datasets you receive from the GOV.UK Verify Hub will be formatted according to the legacy JSON matching schema:
+
+```json
+{
+    "properties": {
+        "cycle3Dataset": {
+            "properties": {
+                "attributes": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "hashedPid": {
+            "type": "string"
+        },
+        "levelOfAssurance": {
+            "enum": [
+                "LEVEL_1",
+                "LEVEL_2",
+                "LEVEL_3",
+                "LEVEL_4"
+            ],
+            "type": "string"
+        },
+        "matchId": {
+            "type": "string"
+        },
+        "matchingDataset": {
+            "properties": {
+                "addresses": {
+                    "items": {
+                        "properties": {
+                            "fromDate": {
+                                "format": "DATE_TIME",
+                                "type": "string"
+                            },
+                            "internationalPostCode": {
+                                "type": "string"
+                            },
+                            "lines": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "postCode": {
+                                "type": "string"
+                            },
+                            "toDate": {
+                                "format": "DATE_TIME",
+                                "type": "string"
+                            },
+                            "uprn": {
+                                "type": "string"
+                            },
+                            "verified": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "dateOfBirth": {
+                    "properties": {
+                        "from": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "to": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "value": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "verified": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "firstName": {
+                    "properties": {
+                        "from": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "to": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        },
+                        "verified": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "gender": {
+                    "properties": {
+                        "from": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "to": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "value": {
+                            "enum": [
+                                "FEMALE",
+                                "MALE",
+                                "NOT_SPECIFIED"
+                            ],
+                            "type": "string"
+                        },
+                        "verified": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "middleNames": {
+                    "properties": {
+                        "from": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "to": {
+                            "format": "DATE_TIME",
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        },
+                        "verified": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "surnames": {
+                    "items": {
+                        "properties": {
+                            "from": {
+                                "format": "DATE_TIME",
+                                "type": "string"
+                            },
+                            "to": {
+                                "format": "DATE_TIME",
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "verified": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object",
+    "required": [ "matchId", "levelOfAssurance", "hashedPid", "matchingDataset" ]
+}
+```

--- a/source/legacy/build-ms/respond-to-matching-requests/universal-json-schema/index.html.md.erb
+++ b/source/legacy/build-ms/respond-to-matching-requests/universal-json-schema/index.html.md.erb
@@ -1,0 +1,387 @@
+---
+title: Universal JSON schema
+weight: 10
+---
+
+# Universal JSON schema
+
+Below is the universal [JSON schema](http://json-schema.org/) for a matching request. You can use this schema to validate incoming matching requests and as a reference when developing your local matching service.
+
+The universal JSON matching schema will be used to represent both Verify  identities and European identities. This schema only applies if your [MSA is configured to use European identities](LINK). Otherwise your MSA will use the [legacy JSON matching schema](LINK).
+
+```json
+  {
+   "properties": {
+     "cycle3Dataset": {
+       "properties": {
+         "attributes": {
+           "additionalProperties": {
+             "type": "string"
+           },
+           "type": "object"
+         }
+       },
+       "type": "object"
+     },
+     "hashedPid": {
+       "type": "string"
+     },
+     "levelOfAssurance": {
+       "enum": [
+         "LEVEL_1",
+         "LEVEL_2",
+         "LEVEL_3",
+         "LEVEL_4"
+       ]
+     },
+     "matchId": {
+       "type": "string"
+     },
+     "matchingDataset": {
+       "properties": {
+         "addresses": {
+           "items": {
+             "properties": {
+               "from": {
+                 "format": "date-time"
+               },
+               "internationalPostCode": {
+                 "type": "string"
+               },
+               "lines": {
+                 "items": {
+                   "type": "string"
+                 },
+                 "type": "array"
+               },
+               "postCode": {
+                 "type": "string"
+               },
+               "to": {
+                 "format": "date-time"
+               },
+               "uprn": {
+                 "type": "string"
+               },
+               "verified": {
+                 "type": "boolean"
+               }
+             },
+             "type": "object"
+           },
+           "type": "array"
+         },
+         "dateOfBirth": {
+           "properties": {
+             "from": {
+               "format": "date-time"
+             },
+             "to": {
+               "format": "date-time"
+             },
+             "value": {
+               "format": "date"
+             },
+             "verified": {
+               "type": "boolean"
+             }
+           },
+           "type": "object"
+         },
+         "firstName": {
+           "properties": {
+             "from": {
+               "format": "date-time"
+             },
+             "to": {
+               "format": "date-time"
+             },
+             "value": {
+               "type": "string"
+             },
+             "nonLatinScriptValue": {
+               "type": "string"
+             },
+             "verified": {
+               "type": "boolean"
+             }
+           },
+           "type": "object"
+         },
+         "gender": {
+           "properties": {
+             "from": {
+               "format": "date-time"
+             },
+             "to": {
+               "format": "date-time"
+             },
+             "value": {
+               "enum": [
+                 "FEMALE",
+                 "MALE",
+                 "NOT_SPECIFIED"
+               ]
+             },
+             "verified": {
+               "type": "boolean"
+             }
+           },
+           "type": "object"
+         },
+         "middleNames": {
+           "properties": {
+             "from": {
+               "format": "date-time"
+             },
+             "to": {
+               "format": "date-time"
+             },
+             "value": {
+               "type": "string"
+             },
+             "verified": {
+               "type": "boolean"
+             }
+           },
+           "type": "object"
+         },
+         "surnames": {
+           "items": {
+             "properties": {
+               "from": {
+                 "format": "date-time"
+               },
+               "to": {
+                 "format": "date-time"
+               },
+               "value": {
+                 "type": "string"
+               },
+               "nonLatinScriptValue": {
+                 "type": "string"
+               },
+               "verified": {
+                 "type": "boolean"
+               }
+             },
+             "type": "object"
+           },
+           "type": "array"
+         }
+       },
+       "type": "object",
+       "required": ["dateOfBirth", "firstName", "surnames"]
+     }
+   },
+   "type": "object",
+   "required": [ "matchId", "levelOfAssurance", "hashedPid", "matchingDataset" ]
+  }
+```
+
+
+## Example for Verify cycle 1 matching request
+
+The MSA sends one matching request for both Cycle 0 and Cycle 1 to your local matching service. Below is a formatted example for a GOV.UK Verify identity using the universal JSON schema.
+
+```json
+{
+    "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+    "levelOfAssurance": "LEVEL_2",
+    "matchId": "default-request-id",
+    "matchingDataset": {
+        "addresses": [
+            {
+                "from": "1980-05-24T00:00:00.000Z",
+                "internationalPostCode": "GB1 2PP",
+                "lines": [
+                    "123 George Street"
+                ],
+                "postCode": "GB1 2PP",
+                "to": "2005-05-14T00:00:00.000Z",
+                "uprn": "7D68E096-5510-B3844C0BA3FD",
+                "verified": true
+            },
+            {
+                "from": "2005-05-14T00:00:00.000Z",
+                "internationalPostCode": "GB1 2PF",
+                "lines": [
+                    "10 George Street"
+                ],
+                "postCode": "GB1 2PF",
+                "uprn": "833F1187-9F33-A7E27B3F211E",
+                "verified": true
+            }
+        ],
+        "dateOfBirth": {
+            "value": "1980-05-24",
+            "verified": true
+        },
+        "firstName": {
+            "value": "Joe",
+            "nonLatinScriptValue": "",
+            "verified": true
+        },
+        "gender": {
+            "value": "MALE",
+            "verified": true
+        },
+        "middleNames": {
+            "value": "Bob Rob",
+            "verified": true
+        },
+        "surnames": [
+            {
+                "from": "1980-05-24T00:00:00.000Z",
+                "to": "2010-01-20T00:00:00.000Z",
+                "value": "Fred",
+                "nonLatinScriptValue": "",
+                "verified": true
+            },
+            {
+                "from": "2010-01-20T00:00:00.000Z",
+                "value": "Dou",
+                "verified": true
+            }
+        ]
+    }
+}
+```
+
+## Example for Verify cycle 3 matching request
+
+If you're using cycle 3 and your local matching service returned a ``no-match`` response to the MSA, the MSA sends a cycle 3 matching request.  Below is a formatted example for a GOV.UK Verify identity using :ref:`the universal JSON schema<JSONschema>`.
+
+A cycle 3 matching request for a :ref:`European identity<eIDASintro>`, will be formatted as shown below.
+
+```json
+{
+    "cycle3Dataset": {
+        "attributes": {
+            "drivers_licence": "4C22DA90A18A4B88BE460E0A3D975F68"
+        }
+    },
+    "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+    "levelOfAssurance": "LEVEL_2",
+    "matchId": "default-request-id",
+    "matchingDataset": {
+        "addresses": [
+            {
+                "from": "1980-05-24T00:00:00.000Z",
+                "internationalPostCode": "GB1 2PP",
+                "lines": [
+                    "123 George Street"
+                ],
+                "postCode": "GB1 2PP",
+                "to": "2005-05-14T00:00:00.000Z",
+                "uprn": "7D68E096-5510-B3844C0BA3FD",
+                "verified": true
+            },
+            {
+                "from": "2005-05-14T00:00:00.000Z",
+                "internationalPostCode": "GB1 2PF",
+                "lines": [
+                    "10 George Street"
+                ],
+                "postCode": "GB1 2PF",
+                "uprn": "833F1187-9F33-A7E27B3F211E",
+                "verified": true
+            }
+        ],
+        "dateOfBirth": {
+            "value": "1980-05-24",
+            "verified": true
+        },
+        "firstName": {
+            "value": "Joe",
+            "nonLatinScriptValue": "",
+            "verified": true
+        },
+        "gender": {
+            "value": "MALE",
+            "verified": true
+        },
+        "middleNames": {
+            "value": "Bob Rob",
+            "verified": true
+        },
+        "surnames": [
+            {
+                "from": "1980-05-24T00:00:00.000Z",
+                "to": "2010-01-20T00:00:00.000Z",
+                "value": "Fred",
+                "nonLatinScriptValue": "",
+                "verified": true
+            },
+            {
+                "from": "2010-01-20T00:00:00.000Z",
+                "value": "Dou",
+                "verified": true
+            }
+        ]
+    }
+}
+```
+
+## Example for European identity cycle 1 matching request
+
+```json
+{
+    "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+    "levelOfAssurance": "LEVEL_2",
+    "matchId": "default-request-id",
+    "matchingDataset": {
+        "dateOfBirth": {
+            "value": "1980-05-24",
+            "verified": true
+        },
+        "firstName": {
+            "value": "Alexander",
+            "nonLatinScriptValue": "Αλέξανδρος",
+            "verified": true
+        },
+        "surnames": [
+            {
+                "value": "Eliopoulos",
+                "nonLatinScriptValue": "Ελιόπουλος",
+                "verified": true
+            }
+        ]
+    }
+}
+```
+
+## Example for European identity cycle 3 matching request
+
+A cycle 3 matching request for a :ref:`European identity<eIDASintro>`, will be formatted as shown below. If you haven't enabled European identities in your MSA configuration, the matching request will be formatted using :ref:`the legacy JSON schema<legacyJSONcycle01>`
+
+```json
+{
+  "cycle3Dataset": {
+      "attributes": {
+          "drivers_licence": "4C22DA90A18A4B88BE460E0A3D975F68"
+      }
+  },
+  "hashedPid": "8a5db0ad424efe4e09622cc4a876cc4c338558384752b483ff69dda4dca1ef04",
+  "levelOfAssurance": "LEVEL_2",
+  "matchId": "default-request-id",
+  "matchingDataset": {
+      "dateOfBirth": {
+          "value": "1980-05-24",
+          "verified": true
+      },
+      "firstName": {
+          "value": "Alexander",
+          "nonLatinScriptValue": "Αλέξανδρος",
+          "verified": true
+      },
+      "surnames": [
+          {
+              "value": "Eliopoulos",
+              "nonLatinScriptValue": "Ελιόπουλος",
+              "verified": true
+          }
+      ]
+  }
+}
+```

--- a/source/legacy/build-ms/respond-to-matching-requests/universal-json-schema/index.html.md.erb
+++ b/source/legacy/build-ms/respond-to-matching-requests/universal-json-schema/index.html.md.erb
@@ -250,9 +250,9 @@ The MSA sends one matching request for both Cycle 0 and Cycle 1 to your local ma
 
 ## Example for Verify cycle 3 matching request
 
-If you're using cycle 3 and your local matching service returned a ``no-match`` response to the MSA, the MSA sends a cycle 3 matching request.  Below is a formatted example for a GOV.UK Verify identity using :ref:`the universal JSON schema<JSONschema>`.
+If you're using cycle 3 and your local matching service returned a `no-match` response to the MSA, the MSA sends a cycle 3 matching request.  Below is a formatted example for a GOV.UK Verify identity using [the universal JSON schema](LINK) .
 
-A cycle 3 matching request for a :ref:`European identity<eIDASintro>`, will be formatted as shown below.
+A cycle 3 matching request for a [European identity](LINK) , will be formatted as shown below.
 
 ```json
 {
@@ -353,7 +353,7 @@ A cycle 3 matching request for a :ref:`European identity<eIDASintro>`, will be f
 
 ## Example for European identity cycle 3 matching request
 
-A cycle 3 matching request for a :ref:`European identity<eIDASintro>`, will be formatted as shown below. If you haven't enabled European identities in your MSA configuration, the matching request will be formatted using :ref:`the legacy JSON schema<legacyJSONcycle01>`
+A cycle 3 matching request for a [European identity](LINK) , will be formatted as shown below. If you haven't enabled European identities in your MSA configuration, the matching request will be formatted using [the legacy JSON schema](LINK) 
 
 ```json
 {

--- a/source/legacy/build-ms/test-ms/index.html.md.erb
+++ b/source/legacy/build-ms/test-ms/index.html.md.erb
@@ -1,6 +1,146 @@
 ---
-title: Title
+title: Test your matching service
 weight: 30
 ---
 
-# Title
+# Test your matching service
+
+You can test your matching service with 2 tools provided by GOV.UK Verify:
+
+* Matching Service Test Tool
+* Compliance Tool
+
+## Using the Matching Service Test Tool
+
+The [Matching Service Test Tool ](https://github.com/alphagov/verify-matching-service-adapter/tree/master/verify-matching-service-test-tool)_ is a lightweight tool you can add to your existing testing workflow.
+
+The tool makes sure your Local Matching Service can:
+
+* handle matching datasets
+* find and match records correctly
+* handle matching failures
+
+You can also add or amend test scenarios to the tool. Refer to the [Matching Service Test Tool documentation on GitHub ](https://github.com/alphagov/verify-matching-service-adapter/tree/master/verify-matching-service-test-tool)_ to install and configure the tool.
+
+## Using the Compliance Tool
+
+The SAML Compliance Tool helps you test your Local Matching Service and Matching Service Adapter (MSA) together. It also helps you to test and configure your MSA before entering the [Integration environment ](LINK).
+
+The Compliance Tool is hosted by GOV.UK Verify. To test the matching service using the Compliance Tool, you will need to make sure your MSA is accessible through the internet.
+
+1. To set up the SAML Compliance Tool for matching service tests, POST the following JSON (via cURL or Postman, for example) to the SAML compliance tool URL ([https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/matching-service-test-run ](https://compliance-tool-reference.ida.digital.cabinet-office.gov.uk/matching-service-test-run)):
+
+      ```
+      Content-Type: application/json
+       {
+       "matchingServiceEntityId": "[entityID of the matching service]",
+       "serviceEntityId": "[entityID of the transaction (service)]",
+       "matchingServiceEndpoint": "[the matching service's endpoint]",
+       "matchingServiceSigningCertificate": "[signing certificate to verify the response]",
+       "matchingServiceEncryptionCertificate": "[encryption certificate to encrypt the assertions]",
+       "userAccountCreationEndpoint": "[optionally the matching service adapter's user account creation endpoint]"
+       }
+      ```
+
+If your service [creates new user accounts ](LINK) then you will need to provide a value for `"userAccountCreationEndpoint"`.
+
+2. You receive a response similar to the following:
+
+      ```
+      Status 201 Created
+      Location: .../matching-service-test-run/8fd7782f-efac-48b2-8171-3e4da9553d19
+      ```
+
+3. POST your test matching dataset (see example below) to the `Location` field in the above response (`.../matching-service-test-run/8fd7782f-efac-48b2-8171-3e4da9553d19` in the above example).
+
+      ```json
+      {
+          "levelOfAssurance": "LEVEL_2",
+          "persistentId": "93E5910B-F4C2-4561-AEC5-C878AFEF25A3",
+          "firstName": {
+              "value": "Joe",
+              "to": "",
+              "from": "",
+              "verified": true
+          },
+          "middleNames": {
+              "value": "Bob Rob",
+              "to": "",
+              "from": "",
+              "verified": true
+          },
+          "surnames": [
+              {
+                  "value": "Fred",
+                  "to": "2010-01-20",
+                  "from": "1980-05-24",
+                  "verified": true
+              },
+              {
+                  "value": "Dou",
+                  "to": "",
+                  "from": "2010-01-20",
+                  "verified": true
+              }
+          ],
+          "gender": {
+              "value": "Male",
+              "to": "",
+              "from": "",
+              "verified": true
+          },
+          "dateOfBirth": {
+              "value": "1980-05-24",
+              "to": "",
+              "from": "",
+              "verified": true
+          },
+          "addresses": [
+              {
+                  "lines": ["123 George Street"],
+                  "postCode": "GB1 2PP",
+                  "internationalPostCode": "GB1 2PP",
+                  "uprn": "7D68E096-5510-B3844C0BA3FD",
+                  "toDate": "2005-05-14",
+                  "fromDate": "1980-05-24",
+                  "verified": true
+              },
+              {
+                  "lines": ["10 George Street"],
+                  "postCode": "GB1 2PF",
+                  "internationalPostCode": "GB1 2PF",
+                  "uprn": "833F1187-9F33-A7E27B3F211E",
+                  "toDate": null,
+                  "fromDate": "2005-05-14",
+                  "verified": true
+              }
+          ],
+          "cycle3Dataset": {
+              "key": "drivers_licence",
+              "value": "4C22DA90A18A4B88BE460E0A3D975F68"
+          },
+          "userAccountCreationAttributes": ["optional", "list", "of", "attributes", "the", "government", "service", "requires", "for", "new", "user", "account", "creation", "see", "below"]
+      }
+      ```
+
+      If you provide a value for `"userAccountCreationAttributes"` the Compliance Tool will make a user account creation request to the `"userAccountCreationEndpoint"` configured in the POST request to /matching-service-test-run.
+      If you do not provide a value, the compliance tool will make a matching request to your `"matchingServiceEndpoint"`.
+
+      You only need to test the user account creation requests if your service [creates new user accounts ](LINK).
+
+      where:
+
+  * `persistentId` is mandatory
+  * you must supply at least one other value in addition to `persistentId`
+  * the values of `addresses`
+  and `surnames` are arrays
+  * fields have optional `from` and `to` attributes in which you can capture historical values – for example, if the user has changed their surname, there's an additional entry for the old surname with the `from` and `to` values defining the period for which the name was valid; the new surname only has the `from` attribute, containing the date from which it was valid
+  * the `addresses` field that holds the current address contains a `fromDate` attribute for the date from which the address is valid; past addresses also contain the `toDate` attribute
+  * the `cycle3Dataset` field is only present for a cycle 3 matching attempt
+  * the `uprn` (Unique Property Reference Number) is a unique reference for each property in Great Britain, ensuring accuracy of address data. This is an optional attribute that can contain up to 12 characters and should not have any leading zeros
+  * `userAccountCreationAttributes`: provide this only if you want to test [new user account creation ](LINK) – select from the full [list of attributes ](LINK)
+
+
+4. When the SAML Compliance Tool receives your test matching dataset, it will POST an attribute query to your MSA. This corresponds to step 4 in the [SAML message flow ](LINK).
+
+5. Your MSA validates the query and sends a POST with a JSON request containing your test matching dataset to your local matching service. This corresponds to step 5 in the [SAML message flow ](LINK).

--- a/source/legacy/build-ms/test-ms/index.html.md.erb
+++ b/source/legacy/build-ms/test-ms/index.html.md.erb
@@ -12,7 +12,7 @@ You can test your matching service with 2 tools provided by GOV.UK Verify:
 
 ## Using the Matching Service Test Tool
 
-The [Matching Service Test Tool ](https://github.com/alphagov/verify-matching-service-adapter/tree/master/verify-matching-service-test-tool)_ is a lightweight tool you can add to your existing testing workflow.
+The [Matching Service Test Tool ](https://github.com/alphagov/verify-matching-service-adapter/tree/master/verify-matching-service-test-tool) is a lightweight tool you can add to your existing testing workflow.
 
 The tool makes sure your Local Matching Service can:
 
@@ -20,7 +20,7 @@ The tool makes sure your Local Matching Service can:
 * find and match records correctly
 * handle matching failures
 
-You can also add or amend test scenarios to the tool. Refer to the [Matching Service Test Tool documentation on GitHub ](https://github.com/alphagov/verify-matching-service-adapter/tree/master/verify-matching-service-test-tool)_ to install and configure the tool.
+You can also add or amend test scenarios to the tool. Refer to the [Matching Service Test Tool documentation on GitHub ](https://github.com/alphagov/verify-matching-service-adapter/tree/master/verify-matching-service-test-tool) to install and configure the tool.
 
 ## Using the Compliance Tool
 
@@ -42,7 +42,7 @@ The Compliance Tool is hosted by GOV.UK Verify. To test the matching service usi
        }
       ```
 
-If your service [creates new user accounts ](LINK) then you will need to provide a value for `"userAccountCreationEndpoint"`.
+      If your service [creates new user accounts ](LINK) then you will need to provide a value for `"userAccountCreationEndpoint"`.
 
 2. You receive a response similar to the following:
 
@@ -129,17 +129,15 @@ If your service [creates new user accounts ](LINK) then you will need to provide
       You only need to test the user account creation requests if your service [creates new user accounts ](LINK).
 
       where:
-
-  * `persistentId` is mandatory
-  * you must supply at least one other value in addition to `persistentId`
-  * the values of `addresses`
-  and `surnames` are arrays
-  * fields have optional `from` and `to` attributes in which you can capture historical values – for example, if the user has changed their surname, there's an additional entry for the old surname with the `from` and `to` values defining the period for which the name was valid; the new surname only has the `from` attribute, containing the date from which it was valid
-  * the `addresses` field that holds the current address contains a `fromDate` attribute for the date from which the address is valid; past addresses also contain the `toDate` attribute
-  * the `cycle3Dataset` field is only present for a cycle 3 matching attempt
-  * the `uprn` (Unique Property Reference Number) is a unique reference for each property in Great Britain, ensuring accuracy of address data. This is an optional attribute that can contain up to 12 characters and should not have any leading zeros
-  * `userAccountCreationAttributes`: provide this only if you want to test [new user account creation ](LINK) – select from the full [list of attributes ](LINK)
-
+      * `persistentId` is mandatory
+      * you must supply at least one other value in addition to `persistentId`
+      * the values of `addresses`
+      and `surnames` are arrays
+      * fields have optional `from` and `to` attributes in which you can capture historical values – for example, if the user has changed their surname, there's an additional entry for the old surname with the `from` and `to` values defining the period for which the name was valid; the new surname only has the `from` attribute, containing the date from which it was valid
+      * the `addresses` field that holds the current address contains a `fromDate` attribute for the date from which the address is valid; past addresses also contain the `toDate` attribute
+      * the `cycle3Dataset` field is only present for a cycle 3 matching attempt
+      * the `uprn` (Unique Property Reference Number) is a unique reference for each property in Great Britain, ensuring accuracy of address data. This is an optional attribute that can contain up to 12 characters and should not have any leading zeros
+      * `userAccountCreationAttributes`: provide this only if you want to test [new user account creation ](LINK) – select from the full [list of attributes ](LINK)
 
 4. When the SAML Compliance Tool receives your test matching dataset, it will POST an attribute query to your MSA. This corresponds to step 4 in the [SAML message flow ](LINK).
 

--- a/source/legacy/build-ms/test-ms/index.html.md.erb
+++ b/source/legacy/build-ms/test-ms/index.html.md.erb
@@ -1,0 +1,6 @@
+---
+title: Title
+weight: 30
+---
+
+# Title

--- a/source/legacy/create-datasources/index.html.md.erb
+++ b/source/legacy/create-datasources/index.html.md.erb
@@ -13,15 +13,13 @@ Create new user accounts using the hashed persistent identifier (PID) and a subs
 
 ## Prerequisites
 
-1.	Configure your MSA to create user accounts.
-
-  - In the [YAML configuration file ](LINK), enter your local matching service '`accountCreationUrl:`'
+1. Configure your MSA to create user accounts.
+      In the [YAML configuration file ](LINK), enter your local matching service '`accountCreationUrl:`'
 
 2. On the [Request access to an environment ](LINK) form:
 
-  - Enter the fully qualified URL that will receive your *Unknown User Attribute* requests from the environment
-
-  - Select any of the following user attributes you require for your service
+      - Enter the fully qualified URL that will receive your *Unknown User Attribute* requests from the environment
+      - Select any of the following user attributes you require for your service
 
       ```
       FIRST_NAME
@@ -50,12 +48,10 @@ In this example, all 3 [matching cycles ](LINK) previously failed to find a matc
 
 1. Your local matching service sends a `no-match` response to the hub via the MSA.
 1. The GOV.UK Verify hub:
-
     * checks that your matching service supports the creation of user accounts
     * identifies the attributes you previously said your service needs to create a user account
 
 1. If your service supports the creation of user accounts, the hub sends a query to the MSA. It contains the:
-
     * matching dataset
     * hashed PID
     * level of assurance
@@ -91,22 +87,19 @@ In this example, all 3 [matching cycles ](LINK) previously failed to find a matc
       A user account isn't created at this point. The final response the hub sends to your service will contain the attributes you need to create a user account.
 
       The local matching service may return `{ "result": "failure" }` if:
-
-        * the level of assurance in the JSON request sent by the MSA is lower than the level of assurance required by the service
-        * there are exceptional circumstances, such as maintenance, when you want to suspend user account creation
+      * the level of assurance in the JSON request sent by the MSA is lower than the level of assurance required by the service
+      * there are exceptional circumstances, such as maintenance, when you want to suspend user account creation
 
 7. The MSA extracts the required attributes from the matching dataset.
 
 8. The MSA sends the extracted attributes, the hashed PID and the level of assurance to your service via the GOV.UK Verify hub.
 
       The MSA must send this data via the GOV.UK Verify hub, to respect the following identity assurance principles:
-
       * user control - users must give informed consent for their information to be used to create an account; they must also be allowed to check their information before you create the account
       * data minimisation – the service receives only the restricted set of attributes it needs, not the full matching dataset.
 
       For more information see the [Identity Assurance Principles ](https://www.gov.uk/government/consultations/draft-identity-assurance-principles/privacy-and-consumer-advisory-group-draft-identity-assurance-principles#the-nine-identity-assurance-principles).
 
 9. The government service:
-
       * creates a user account using the attributes extracted from the matching dataset
       * sets up a correlation between the user account and the user's hashed PID

--- a/source/legacy/create-datasources/index.html.md.erb
+++ b/source/legacy/create-datasources/index.html.md.erb
@@ -1,0 +1,112 @@
+---
+title: Create user accounts (optional)
+weight: 50
+---
+
+# Create user accounts (optional)
+
+If Verify fails to identify the user, you can enable your service to create a new user account.
+
+You must obtain explicit user consent before creating a user account.
+
+Create new user accounts using the hashed persistent identifier (PID) and a subset of attributes from the matching dataset listed below.
+
+## Prerequisites
+
+1.	Configure your MSA to create user accounts.
+
+  - In the [YAML configuration file ](LINK), enter your local matching service '`accountCreationUrl:`'
+
+2. On the [Request access to an environment ](LINK) form:
+
+  - Enter the fully qualified URL that will receive your *Unknown User Attribute* requests from the environment
+
+  - Select any of the following user attributes you require for your service
+
+      ```
+      FIRST_NAME
+      FIRST_NAME_VERIFIED
+      MIDDLE_NAME
+      MIDDLE_NAME_VERIFIED
+      SURNAME
+      SURNAME_VERIFIED
+      DATE_OF_BIRTH
+      DATE_OF_BIRTH_VERIFIED
+      CURRENT_ADDRESS
+      CURRENT_ADDRESS_VERIFIED
+      ADDRESS_HISTORY
+      CYCLE_3
+      ```
+
+      User Accounts can only be created with the user's current 'NAME' and 'Date of Birth' data.  ADDRESS_HISTORY will return any address known to be associated with the user, within the last three years.
+
+## Message flow
+
+This diagram shows the message flow for creating user accounts. In this example, the service has been set up to create user accounts when matching fails.
+
+**FIGURE: createanaccount.svg**
+
+In this example, all 3 [matching cycles ](LINK) previously failed to find a match for the user in the government service records.
+
+1. Your local matching service sends a `no-match` response to the hub via the MSA.
+1. The GOV.UK Verify hub:
+
+    * checks that your matching service supports the creation of user accounts
+    * identifies the attributes you previously said your service needs to create a user account
+
+1. If your service supports the creation of user accounts, the hub sends a query to the MSA. It contains the:
+
+    * matching dataset
+    * hashed PID
+    * level of assurance
+    * list of attributes to extract from the matching dataset
+
+4. The MSA POSTs the following JSON to the local matching service's account creation URI endpoint:
+
+    ```
+    [{
+    "hashedPid": "<string value>",
+    "levelOfAssurance": "<the level of assurance, e.g. LEVEL_1>"
+    }]
+    ```
+
+5. Optionally, the local matching service stores the hashed PID and level of assurance in the local matching datastore.
+
+    You'll need to create a correlation between the user account and the hashed PID, so a returning user can match with [cycle 0 ](LINK). You can choose to store the hashed PID at this point and create a correlation between the user account and the hashed PID at step 9. Alternatively, you can create the user account, store the hashed PID and set up the correlation at step 9.
+
+6. The local matching service sends a JSON response to the MSA:
+
+      ```
+      { "result": "success" }
+      ```
+      or
+
+
+      ```
+      { "result": "failure" }
+      ```
+
+      As shown above, `success` and `failure` must be in lower case.
+
+      A user account isn't created at this point. The final response the hub sends to your service will contain the attributes you need to create a user account.
+
+      The local matching service may return `{ "result": "failure" }` if:
+
+        * the level of assurance in the JSON request sent by the MSA is lower than the level of assurance required by the service
+        * there are exceptional circumstances, such as maintenance, when you want to suspend user account creation
+
+7. The MSA extracts the required attributes from the matching dataset.
+
+8. The MSA sends the extracted attributes, the hashed PID and the level of assurance to your service via the GOV.UK Verify hub.
+
+      The MSA must send this data via the GOV.UK Verify hub, to respect the following identity assurance principles:
+
+      * user control - users must give informed consent for their information to be used to create an account; they must also be allowed to check their information before you create the account
+      * data minimisation – the service receives only the restricted set of attributes it needs, not the full matching dataset.
+
+      For more information see the [Identity Assurance Principles ](https://www.gov.uk/government/consultations/draft-identity-assurance-principles/privacy-and-consumer-advisory-group-draft-identity-assurance-principles#the-nine-identity-assurance-principles).
+
+9. The government service:
+
+      * creates a user account using the attributes extracted from the matching dataset
+      * sets up a correlation between the user account and the user's hashed PID

--- a/source/legacy/index.html.md.erb
+++ b/source/legacy/index.html.md.erb
@@ -1,0 +1,10 @@
+---
+title: Legacy
+weight: 100
+---
+
+# Legacy
+
+This section contains documentation for components no longer required to connect your service to Verify.
+
+Because they are no longer a requirement for the connection, the components are no longer supported by the GOV.UK Verify team.

--- a/source/open-components/information-only/index.html.md.erb
+++ b/source/open-components/information-only/index.html.md.erb
@@ -9,22 +9,14 @@ The code listed below is provided for informational purposes only and not yet in
 
 | Repository                   | Description                        |
 |-----------------------------|------------------------------------|
-| `verify-sample-local-matching-services` | A test project with a variety of sample local matching services in various languages                           |
-| `verify-saml-libs`                      | Verify SAMl libraries                                                                                          |
-| `verify-test-utils`                     | Libraries to help write Java Unit and Integration tests                                                        |
-| `verify-utils-libs`                     | Libraries used for REST, security and common utilities                                                         |
-| `verify-dev-pki`                        | Contains keys and certificates for Verify integration tests                                                    |
-| `verify-stub-idp-saml`                  | SAML library for a dummy Identity Provider IDP                                                                 |
-| `verify-shibboleth-sp-example`          | An example configuration for a Shibboleth SP instance that works with Verify                                   |
-| `verify-dropwizard-saml`                | Library for providing a SAML configuration object                                                              |
-| `verify-metadata-generator`             | Produces unsigned SAML metadata that can be used to describe the entities within the GOV.UK Verify federation. |
+| [verify-sample-local-matching-services] | A test project with a variety of sample local matching services in various languages                           |
+| [verify-saml-libs]                      | Verify SAMl libraries                                                                                          |
+| [verify-test-utils]                   | Libraries to help write Java Unit and Integration tests                                                        |
+| [verify-utils-libs]                     | Libraries used for REST, security and common utilities                                                         |
+| [verify-dev-pki]                        | Contains keys and certificates for Verify integration tests                                                    |
+| [verify-stub-idp-saml]                  | SAML library for a dummy Identity Provider IDP                                                                 |
+| [verify-shibboleth-sp-example]          | An example configuration for a Shibboleth SP instance that works with Verify                                   |
+| [verify-dropwizard-saml]                | Library for providing a SAML configuration object                                                              |
+| [verify-metadata-generator]             | Produces unsigned SAML metadata that can be used to describe the entities within the GOV.UK Verify federation. |
 
-_verify-sample-local-matching-services: https://github.com/alphagov/verify-sample-local-matching-services
-_verify-test-utils: https://github.com/alphagov/verify-test-utils
-_verify-utils-libs: https://github.com/alphagov/verify-utils-libs
-_verify-dev-pki: https://github.com/alphagov/verify-dev-pki
-_verify-stub-idp-saml: https://github.com/alphagov/verify-stub-idp-saml
-_verify-shibboleth-sp-example: https://github.com/alphagov/verify-shibboleth-sp-example
-_verify-dropwizard-saml: https://github.com/alphagov/verify-dropwizard-saml
-_verify-metadata-generator: https://github.com/alphagov/verify-metadata-generator
-_verify-saml-libs: https://github.com/alphagov/verify-saml-libs
+<%= partial "partials/links" %>

--- a/source/open-components/open-use/index.html.md.erb
+++ b/source/open-components/open-use/index.html.md.erb
@@ -7,32 +7,19 @@ weight: 10
 
 | Repository | Description |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `verify-frontend`                  | The frontend service for Verify                                                                                                |
-| `passport-verify`                  | A passport.js strategy for Verify implementation in node.js and passport.js to integrate with Verify                           |
-| `verify-compliance-tool-gui`       | A graphical user interface for the Verify compliance tool                                                                      |
-| `verify-matching-service-adapter`  | An application that a Relying Party must operate to facilitate user matching requests from Verify                              |
-| `verify-service-provider`          | A Dropwizard application to generate and translate SAML requests and responses                                                 |
-| `verify-stub-matching-service`     | A test implementation of a local matching service                                                                              |
-| `verify-hub`                       | A system of microservices to manage interactions between users, government services, identity providers, and matching services |
-| `verify-stub-idp`                  | A stub Identity Provider and stub EU country used for testing GOV.UK Verify and eIDAS integration                              |
-| `verify-test-rp`                   | A stub Relying Party used when testing the GOV.UK Verify Hub                                                                   |
-| `verify-eidas-metadata-aggregator` | An application that retrieves and validates metadata from EU countries and then copies the valid metadata to an AWS S3 bucket  |
-| `dropwizard-logstash`              | Dropwizard extension that supports logstash format with various appenders                                                      |
-| `dropwizard-jade`                  | Dropwizard extension to use Jade templating engine in Views used by Verify code                                                |
-| `dropwizard-infinispan`            | Dropwizard bundle and configuration for Infinispan                                                                             |
-| `eager-dropwizard-guice`           | Dropwizard-guice library                                                                                                       |
+| [verify-frontend]                  | The frontend service for Verify                                                                                                |
+| [passport-verify]                  | A passport.js strategy for Verify implementation in node.js and passport.js to integrate with Verify                           |
+| [verify-compliance-tool-gui]       | A graphical user interface for the Verify compliance tool                                                                      |
+| [verify-matching-service-adapter]  | An application that a Relying Party must operate to facilitate user matching requests from Verify                              |
+| [verify-service-provider]         | A Dropwizard application to generate and translate SAML requests and responses                                                 |
+| [verify-stub-matching-service]     | A test implementation of a local matching service                                                                              |
+| [verify-hub]                       | A system of microservices to manage interactions between users, government services, identity providers, and matching services |
+| [verify-stub-idp]                 | A stub Identity Provider and stub EU country used for testing GOV.UK Verify and eIDAS integration                              |
+| [verify-test-rp]                   | A stub Relying Party used when testing the GOV.UK Verify Hub                                                                   |
+| [verify-eidas-metadata-aggregator] | An application that retrieves and validates metadata from EU countries and then copies the valid metadata to an AWS S3 bucket  |
+| [dropwizard-logstash]              | Dropwizard extension that supports logstash format with various appenders                                                      |
+| [dropwizard-jade]                  | Dropwizard extension to use Jade templating engine in Views used by Verify code                                                |
+| [dropwizard-infinispan]            | Dropwizard bundle and configuration for Infinispan                                                                             |
+| [eager-dropwizard-guice]           | Dropwizard-guice library                                                                                                       |
 
-.. _dropwizard-logstash: https://github.com/alphagov/dropwizard-logstash
-.. _dropwizard-jade: https://github.com/alphagov/dropwizard-jade
-.. _dropwizard-infinispan: https://github.com/alphagov/dropwizard-infinispan
-.. _eager-dropwizard-guice: https://github.com/alphagov/eager-dropwizard-guice
-.. _passport-verify-stub-relying-party: https://github.com/alphagov/passport-verify-stub-relying-party
-.. _passport-verify: https://github.com/alphagov/passport-verify
-.. _verify-compliance-tool-gui: https://github.com/alphagov/verify-compliance-tool-gui
-.. _verify-matching-service-adapter: https://github.com/alphagov/verify-matching-service-adapter
-.. _verify-service-provider: https://github.com/alphagov/verify-service-provider
-.. _verify-stub-matching-service: https://github.com/alphagov/verify-stub-matching-service
-.. _verify-hub: https://github.com/alphagov/verify-hub
-.. _verify-stub-idp: https://github.com/alphagov/verify-stub-idp
-.. _verify-test-rp: https://github.com/alphagov/verify-test-rp
-.. _verify-eidas-metadata-aggregator: https://github.com/alphagov/verify-eidas-metadata-aggregator
+<%= partial "partials/links" %>

--- a/source/overview/public-key-infrastructure/index.html.md.erb
+++ b/source/overview/public-key-infrastructure/index.html.md.erb
@@ -30,3 +30,66 @@ You are responsible for ensuring that the terms of the IDAP PKI Certification Po
 - IDAP PKI Subscriber Agreement – sets out the terms of use of PKI for those using certificates received from the IDAP PKI
 - IDAP PKI Relying Party Agreement – sets out the terms for those who do not necessarily hold a certificate, but who, during the course of a transaction, may be a recipient of a certificate and place reliance on a certificate and/or digital signatures created using that certificate
 - GOV.UK Verify Certification Process for (Relying Party) Subscribers – indicates the URLs where you can submit certificate requests to the IDAP certificate authority
+
+
+
+## Public keys, private keys, and certificates
+
+
+To encrypt and sign data, you need 2 pairs of keys:
+
+* public and private **encryption** keys
+* public and private **signing** keys
+
+
+The keys consist of very long numbers linked in a particular way so the public key can be derived from the private key but not the other way around. Entities within a PKI generate their own keys. They always retain their private keys. However, they share their public keys with other entities to allow secure communication through [encryption](LINK)
+and [signing](LINK).
+
+Public keys are shared using certificates. A certificate is a file that contains:
+
+* a copy of the certificate owner's public key
+* information about the identity of the certificate owner
+* an indication of the purpose of the certificate, for example, encryption or signing
+
+Certificates are issued and signed by a certificate authority. The certificate authority acts as the trust anchor in the PKI. An entity that receives data from a third party can request confirmation from the certificate authority that the third party's certificate is valid.
+
+
+## Keys and certificates in the GOV.UK Verify federation
+
+The IDAP PKI and GOV.UK Verify federation use the X509 standard for digital certificates.
+
+In the GOV.UK Verify federation, the IDAP certificate authority issues and signs certificates. As a government service using GOV.UK Verify, you need to request 4 certificates:
+
+* encryption and signing certificates for your service
+* encryption and signing certificates for your Matching Service Adapter
+
+
+To obtain a certificate:
+
+1. Generate pair of keys ([private](LINK) and [public](LINK)). You must generate a pair of encryption keys for each encryption certificate request and a pair of signing keys for each signing certificate request.
+1. [Submit a certificate signing request](LINK) to the IDAP certificate authority.
+1. The certificate authority generates your certificate and sends it to you.
+
+The certificate authority also issues certificates for the GOV.UK Verify hub and identity providers.
+
+## Data encryption and signing
+
+Encryption certificates provide the sender with assurance that only the intended receiver can decrypt the message.
+
+The sender extracts the public encryption key from the receiver's encryption certificate and uses it to encrypt a message. The receiver decrypts the message using their corresponding private encryption key.
+
+Signing certificates provide the receiver with assurance of who authored the message. They also guarantee that the message hasn't been tampered with since the author signed it.
+
+When signing data, you use your private signing key to create a digital signature, and then send the signed message. The receivers check the digital signature using your public signing key from your signing certificate.
+
+You can use encryption and signing together or alone.
+
+ **Signing alone**
+
+  When a user indicates that they would like to prove their identity, the government service sends a message to the GOV.UK Verify hub. The message is unencrypted because it contains no personal user information. However, the message is signed because the hub needs assurance that the message originated from the government service.
+
+ **Encryption and signing**
+
+  When a user has verified their identity, the identity provider sends a signed message to the hub containing the user's encrypted personal information. This ensures the confidentiality of the message and that the message originated from the identity provider.
+
+A message can contain embedded messages which may be encrypted and/or signed by different entities within the GOV.UK Verify federation. For more information, see the [diagram showing the SAML message flow](LINK) within the GOV.UK Verify federation.

--- a/source/partials/_env-access.erb
+++ b/source/partials/_env-access.erb
@@ -1,6 +1,7 @@
 
 # Get environment access
 
+An environment is a fully-working deployment of the GOV.UK Verify hub. GOV.UK Verify maintains a number of environments for development, testing, and operational purposes. As a government service you need to work in the integration and production environments.
 
 GOV.UK Verify provides two identical, secure environments:
 
@@ -12,7 +13,7 @@ Integration allows you to test your prototype service with dummy user data.
 <% end %>
 
 <% if env == "Production" %>
-Production allows you to host your fully-developed beta or live service with real user data.
+Production allows you to host your fully-developed beta or live service with real user data. The production environment is where you deploy your live end-to-end service. It's a restricted environment for security reasons.
 <% end %>
 
 You must complete a short form with information about your service so GOV.UK Verify can set up each environment for you. This can take up to 5 working days.

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -1,0 +1,28 @@
+
+
+
+[verify-sample-local-matching-services]: https://github.com/alphagov/verify-sample-local-matching-services
+[verify-test-utils]: https://github.com/alphagov/verify-test-utils
+[verify-utils-libs]: https://github.com/alphagov/verify-utils-libs
+[verify-dev-pki]: https://github.com/alphagov/verify-dev-pki
+[verify-stub-idp-saml]: https://github.com/alphagov/verify-stub-idp-saml
+[verify-shibboleth-sp-example]: https://github.com/alphagov/verify-shibboleth-sp-example
+[verify-dropwizard-saml]: https://github.com/alphagov/verify-dropwizard-saml
+[verify-metadata-generator]: https://github.com/alphagov/verify-metadata-generator
+[verify-saml-libs]: https://github.com/alphagov/verify-saml-libs
+
+[dropwizard-logstash]: https://github.com/alphagov/dropwizard-logstash
+[dropwizard-jade]: https://github.com/alphagov/dropwizard-jade
+[dropwizard-infinispan]: https://github.com/alphagov/dropwizard-infinispan
+[eager-dropwizard-guice]: https://github.com/alphagov/eager-dropwizard-guice
+[passport-verify-stub-relying-party]: https://github.com/alphagov/passport-verify-stub-relying-party
+[passport-verify]: https://github.com/alphagov/passport-verify
+[verify-compliance-tool-gui]: https://github.com/alphagov/verify-compliance-tool-gui
+[verify-matching-service-adapter]: https://github.com/alphagov/verify-matching-service-adapter
+[verify-service-provider]: https://github.com/alphagov/verify-service-provider
+[verify-stub-matching-service]: https://github.com/alphagov/verify-stub-matching-service
+[verify-hub]: https://github.com/alphagov/verify-hub
+[verify-stub-idp]: https://github.com/alphagov/verify-stub-idp
+[verify-test-rp]: https://github.com/alphagov/verify-test-rp
+[verify-eidas-metadata-aggregator]: https://github.com/alphagov/verify-eidas-metadata-aggregator
+[verify-frontend]: https://github.com/alphagov/verify-frontend


### PR DESCRIPTION
Adds legacy matching content to the new docs.
Also implements a single reference file for the links.
Adds content on PKI concepts. This had initially been accidentally left out.