### PR TITLE
Override report problem URL

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,7 +2,7 @@ require 'govuk_tech_docs'
 
 GovukTechDocs::SourceUrls.class_eval do
   def report_issue_url
-    'mailto:helpemepls@gov.uk'
+    'mailto:idasupport@digital.cabinet-office.gov.uk'
   end
 end
 

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,9 @@
 require 'govuk_tech_docs'
 
+GovukTechDocs::SourceUrls.class_eval do
+  def report_issue_url
+    'mailto:helpemepls@gov.uk'
+  end
+end
+
 GovukTechDocs.configure(self)


### PR DESCRIPTION
You can override the default report issue URL by replacing the
string returned by the `report_issue_url` method. The method should
still have access to all the `SourceUrls` class's methods if you want to
include the page title or similar in the URL.

See `lib/govuk_tech_docs/contribution_banner.rb` for the original definition
of this method and to see the available variables.

The URL change only affects this repo.