### PR TITLE
Remove mentions of matching

### DIFF
--- a/source/maintain-your-connection/rotate-keys/index.html.md.erb
+++ b/source/maintain-your-connection/rotate-keys/index.html.md.erb
@@ -7,16 +7,16 @@ weight: 10
 
 When the certificates containing your public keys are due to expire, you must rotate your keys. This allows you to introduce a new set of keys and certificates with no service interruption.
 
-As a government service you are responsible for maintaining the encryption and signing keys for your Matching Service Adapter (MSA) and your service provider. Your service provider could be the [Verify Service Provider (VSP)](https://github.com/alphagov/verify-service-provider) or another service provider.
+As a government service you are responsible for maintaining the encryption and signing keys for your service provider and Matching Service Adapter (MSA), if you are running one. Your service provider could be the [Verify Service Provider (VSP)](https://github.com/alphagov/verify-service-provider) or another service provider.
 
 Before you start rotating keys, you must [get new signed certificates](LINK)for your public keys from the [IDAP certificate authority](http://alphagov.github.io/rp-onboarding-tech-docs/pages/pki/pkiWorks.html#keys-and-certificates-in-the-gov-uk-verify-federation).
 
 Then, as part of the key rotation process, you must rotate your:
 
-* [MSA encryption key](LINK)
-* [MSA signing key](LINK)
 * [VSP encryption key](LINK)or [service provider encryption key](LINK)
 * [VSP signing key](LINK)or [service provider signing key](LINK)
+* [MSA encryption key](LINK)
+* [MSA signing key](LINK)
 
 To communicate with the GOV.UK Verify team during a key rotation process, send an email to idasupport+onboarding@digital.cabinet-office.gov.uk. This will begin an email thread that you can use for any queries you have during this key-rotation process.
 
@@ -29,71 +29,6 @@ To communicate with the GOV.UK Verify team during a key rotation process, send a
 1. [Submit the certificate signing requests](LINK) from step 2 to the IDAP certificate authority.
 
 The IDAP certificate authority will issue you signed certificates for the MSA and your service provider encryption and signing public keys.
-
-## Rotate your MSA encryption key
-
-1. Add a second list item containing the details for your new public and private key under ``encryptionKeys`` in your [MSA configuration ](LINK), for example:
-
-    ```yaml
-    encryptionKeys:
-    - publicKey:
-        certFile: msa_encryption_2016.crt
-        name: MSA Encryption 2016
-      privateKey:
-        keyFile: msa_encryption_2016.pk8
-    - publicKey:
-        certFile: msa_encryption_2017.crt
-        name: MSA Encryption 2017
-      privateKey:
-        keyFile: msa_encryption_2017.pk8
-    ```
-
-1. Restart the MSA to implement the configuration changes -  the MSA can now use both the new and old keys to decrypt SAML messages.
-
-1. Send the new certificate to the GOV.UK Verify team and wait for the team to confirm deployment.
-
-1. After the GOV.UK Verify team confirm they have deployed the new public encryption key, delete the old private encryption key and certificate.
-
-1. Restart the MSA to implement the configuration changes.
-
-The MSA now uses the new encryption key to decrypt SAML messages, and the GOV.UK Verify hub now uses the new key to encrypt SAML messages for your service.
-
-> While both keys are in use, you may see error messages in the logs with the description `Unwrapping failed`. These messages appear because the MSA attempts to decrypt the SAML message using each key in turn. You can safely ignore these messages. However, do not ignore any other error messages related to SAML decryption.
-
-## Rotate your MSA signing key
-
-The MSA publishes its certificates containing the public keys in its own metadata at run time. The service provider you’re using reads this metadata and uses the MSA's signing certificate to trust assertions signed by the MSA. Therefore you must restart the MSA once you've changed the certificates in the configuration file (step 2) and make sure your service provider has read the new metadata (step 3).
-
-1. Send the new signing certificate to the GOV.UK Verify team and add it to the [MSA configuration ](LINK)under `signingKeys.secondary`, for example:
-
-    ```yaml
-    signingKeys:
-      primary:
-        publicKey:
-          certFile: msa_signing_2016.crt
-          name: 2016 MSA Signing Key
-        privateKey:
-          keyFile: msa_signing_2016.pk8
-      secondary:
-        publicKey:
-          certFile: msa_signing_2017.crt
-          name: 2017 MSA Signing Key
-        privateKey:
-          keyFile: msa_signing_2017.pk8
-    ```
-1. Restart the MSA to publish the new signing certificate to its metadata.
-
-1. Make sure your service provider has read the new metadata.
-
-    If you’re using the VSP, wait for it to load the MSA metadata. The VSP periodically refreshes its metadata and will log when it has finished. Once it loads the new metadata, the VSP trusts assertions signed with the new MSA signing key.
-
-1. Delete the `signingKeys.primary` section and rename `signingKeys.secondary` to `signingKeys.primary` - the MSA now signs the assertions with the new  key.
-
-1. Restart the MSA to update its metadata to contain only the new signing certificate.
-
-1. Inform the GOV.UK Verify team that the new key is live.
-
-Your service provider now trusts assertions signed with your new MSA signing key.
 
 ## Rotate your VSP encryption key
 
@@ -137,3 +72,72 @@ These instructions apply to you if you're using an alternative to the Verify Ser
 1. Inform the GOV.UK Verify team that the new key is live - the GOV.UK Verify team removes the old certificate from the GOV.UK Verify hub.
 
 The GOV.UK Verify hub now trusts SAML messages signed with your new service provider signing key.
+
+## Rotate your MSA encryption key
+
+These instructions apply to you if you're using the legacy setup with an MSA.
+
+1. Add a second list item containing the details for your new public and private key under ``encryptionKeys`` in your [MSA configuration ](LINK), for example:
+
+    ```yaml
+    encryptionKeys:
+    - publicKey:
+        certFile: msa_encryption_2016.crt
+        name: MSA Encryption 2016
+      privateKey:
+        keyFile: msa_encryption_2016.pk8
+    - publicKey:
+        certFile: msa_encryption_2017.crt
+        name: MSA Encryption 2017
+      privateKey:
+        keyFile: msa_encryption_2017.pk8
+    ```
+
+1. Restart the MSA to implement the configuration changes -  the MSA can now use both the new and old keys to decrypt SAML messages.
+
+1. Send the new certificate to the GOV.UK Verify team and wait for the team to confirm deployment.
+
+1. After the GOV.UK Verify team confirm they have deployed the new public encryption key, delete the old private encryption key and certificate.
+
+1. Restart the MSA to implement the configuration changes.
+
+The MSA now uses the new encryption key to decrypt SAML messages, and the GOV.UK Verify hub now uses the new key to encrypt SAML messages for your service.
+
+> While both keys are in use, you may see error messages in the logs with the description `Unwrapping failed`. These messages appear because the MSA attempts to decrypt the SAML message using each key in turn. You can safely ignore these messages. However, do not ignore any other error messages related to SAML decryption.
+
+## Rotate your MSA signing key
+
+These instructions apply to you if you're using the legacy setup with an MSA.
+
+The MSA publishes its certificates containing the public keys in its own metadata at run time. The service provider you’re using reads this metadata and uses the MSA's signing certificate to trust assertions signed by the MSA. Therefore you must restart the MSA once you've changed the certificates in the configuration file (step 2) and make sure your service provider has read the new metadata (step 3).
+
+1. Send the new signing certificate to the GOV.UK Verify team and add it to the [MSA configuration ](LINK)under `signingKeys.secondary`, for example:
+
+    ```yaml
+    signingKeys:
+      primary:
+        publicKey:
+          certFile: msa_signing_2016.crt
+          name: 2016 MSA Signing Key
+        privateKey:
+          keyFile: msa_signing_2016.pk8
+      secondary:
+        publicKey:
+          certFile: msa_signing_2017.crt
+          name: 2017 MSA Signing Key
+        privateKey:
+          keyFile: msa_signing_2017.pk8
+    ```
+1. Restart the MSA to publish the new signing certificate to its metadata.
+
+1. Make sure your service provider has read the new metadata.
+
+    If you’re using the VSP, wait for it to load the MSA metadata. The VSP periodically refreshes its metadata and will log when it has finished. Once it loads the new metadata, the VSP trusts assertions signed with the new MSA signing key.
+
+1. Delete the `signingKeys.primary` section and rename `signingKeys.secondary` to `signingKeys.primary` - the MSA now signs the assertions with the new  key.
+
+1. Restart the MSA to update its metadata to contain only the new signing certificate.
+
+1. Inform the GOV.UK Verify team that the new key is live.
+
+Your service provider now trusts assertions signed with your new MSA signing key.

--- a/source/partials/_env-access.erb
+++ b/source/partials/_env-access.erb
@@ -28,8 +28,9 @@ The form does not store data between sessions. You must make sure you have all t
 
 To complete the form you’ll need to share URLs for your:
 
-- service and [Matching Service Adapter](LINK)
-- service start point or page, [Verify SAML response](LINK) and Matching Service
+- service provider
+- service start point or page
+- [Verify SAML response](LINK)
 
 You’ll need to provide web content to personalise the Verify Hub for your end users, including:
 
@@ -40,10 +41,8 @@ You’ll need to provide web content to personalise the Verify Hub for your end 
 
 You’ll need to provide [valid, signed IDAP X.509 Public certificates](LINK) for:
 
-- service signature validation
-- service encryption
-- Matching Service Adapter signature validation
-- Matching Service Adapter encryption
+- service provider signature validation
+- service provider encryption
 
 If applicable to your service, you’ll need to provide:
 

--- a/source/partials/_get-certs.erb
+++ b/source/partials/_get-certs.erb
@@ -54,9 +54,9 @@ openssl genrsa -out <file name>.key 2048
 where:
 
 - `2048` ensures that the private key meets the RSA 2048 standard required by the IDAP certificate authority
-- `<file name>` is a meaningful name, for example `MyserviceDevSamlSigning1.key` or `MyserviceUatMsaSamlEncryption3.key`
+- `<file name>` is a meaningful name, for example `MyserviceDevSamlSigning1.key` or `MyserviceUatVspSamlEncryption3.key`
 
-We advise you to establish a naming convention for all your PKI files. Typically, this includes the name of your service or the MSA and an incremental version number.
+We advise you to establish a naming convention for all your PKI files. Typically, this includes the name of your service provider or the MSA and an incremental version number.
 
 Generate a new private key for each certificate signing request file that you submit. This naturally retires any private keys that have been compromised; you should not re-use existing private keys.
 
@@ -84,7 +84,7 @@ openssl req -new -key <file name>.key -out <file name>.csr
 where:
 
 - `<file name>.key` is the name of the private key file you generated
-- `<file name>.csr` is a meaningful name, for example `MyserviceDevSamlSigning3.csr` or `MyserviceUatMsaSamlEncryption3.csr`
+- `<file name>.csr` is a meaningful name, for example `MyserviceDevSamlSigning3.csr` or `MyserviceUatVspSamlEncryption3.csr`
 
 We advise you to establish a naming convention for all your PKI files. The private key and certificate signing request files can have the same filename as they have different extensions (.key and .csr).
 

--- a/source/plan-your-connection/development-steps/index.html.md.erb
+++ b/source/plan-your-connection/development-steps/index.html.md.erb
@@ -83,17 +83,6 @@ Outcome: you’re ready to connect your service provider to the Production envir
 
 For more information, see [GOV.UK Verify environments](LINK) and [How a PKI works](LINK).
 
-### Connect your service provider to the Production environment.
-
-To do this:
-
-1. [Download and install the Matching Service Adapter](LINK).
-2. [Configure the Matching Service Adapter for the production environment](LINK).
-
-Outcome: your service is ready to go live.
-
-For more information, see [Install and configure the Matching Service Adapter](LINK) and [GOV.UK Verify environments](LINK).
-
 ## Maintenance
 
 ### Rotate your keys.

--- a/source/plan-your-connection/development-steps/index.html.md.erb
+++ b/source/plan-your-connection/development-steps/index.html.md.erb
@@ -29,7 +29,7 @@ For more information, see [How SAML works with GOV.UK Verify](LINK) and the [Ide
 
 You should [use the Compliance Tool to test] that your service provider handles all the required scenarios correctly.
 
-Outcome: your service and matching service can consume and produce valid SAML.
+Outcome: your service provider can consume and produce valid SAML.
 
 For more information, see [How SAML works with GOV.UK Verify](LINK).
 
@@ -54,7 +54,7 @@ To do this:
 
 Outcome: you’re ready to run end-to-end testing with test users.
 
-For more information, see [Install and configure the Matching Service Adapter](LINK) and [GOV.UK Verify environments](LINK).
+For more information, see [GOV.UK Verify environments](LINK).
 
 ### Run end-to-end testing of all your user journeys in the Integration environment.
 
@@ -69,8 +69,6 @@ Outcome: your service can handle all the possible outcomes of end-to-end user jo
 For more information, see [GOV.UK Verify environments](LINK).
 
 ## Connect to Production and go live
-
-Once
 
 ### Request access to the production environment.
 
@@ -89,6 +87,6 @@ For more information, see [GOV.UK Verify environments](LINK) and [How a PKI work
 
 When the certificates containing your public keys are due to expire, [replace your keys and certificates](LINK).
 
-Outcome: the encryption and signing certificates for your service and Matching Service Adapter are up to date.
+Outcome: the encryption and signing certificates for your service provider are up to date.
 
 For more information, see [How a PKI works](LINK).

--- a/source/run-end-to-end-tests/testing/run-end-to-end-tests/index.html.md.erb
+++ b/source/run-end-to-end-tests/testing/run-end-to-end-tests/index.html.md.erb
@@ -5,11 +5,9 @@ weight: 20
 
 # Run end-to-end tests
 
-As a minimum, test the following end-to-end user scenarios:
+The Integration environment is a deployment of the GOV.UK Verify Hub with test identity providers which you should test your user journeys from end to end.
 
-* authentication success and authentication failure
-* match and no-match
-* all the possible outcomes of your matching service, including [Cycle 3](LINK) and [user account creation](LINK), if implemented
+If your service needs to link identities received from Verify to your database, you should also test this.
 
 ## Tear down
 

--- a/source/run-end-to-end-tests/testing/set-up-tests/index.html.md.erb
+++ b/source/run-end-to-end-tests/testing/set-up-tests/index.html.md.erb
@@ -5,7 +5,6 @@ weight: 10
 
 # Set up end-to-end tests
 
-The integration environment is not accredited to use real user data, and it has no links to real identity providers. Carry out business analysis to identify user identities that cause potential problem scenarios during [matching](LINK). Then, in the user administration application programming interface (API), create test users that will test these scenarios. You must also add the test users to your local matching datastore in the integration environment.
 
 A test identity provider contains:
 

--- a/source/run-end-to-end-tests/testing/set-up-tests/index.html.md.erb
+++ b/source/run-end-to-end-tests/testing/set-up-tests/index.html.md.erb
@@ -25,7 +25,7 @@ Setup for end-to-end testing involves the following procedures:
 
 ## Create test users
 
-This procedure describes how to create test users in bulk and load them into the test identity provider. You must add the same test users to your local matching datastore in the integration environment.
+This procedure describes how to create test users in bulk and load them into the test identity provider. You must add the same test users to your local datastore in the integration environment.
 
 Make an HTTP POST to the user administration API with a JSON document containing an array of user data. For example:
 

--- a/source/run-end-to-end-tests/testing/set-up-tests/index.html.md.erb
+++ b/source/run-end-to-end-tests/testing/set-up-tests/index.html.md.erb
@@ -5,6 +5,9 @@ weight: 10
 
 # Set up end-to-end tests
 
+The integration environment is not accredited to use real user data, and it has no links to real identity providers.
+
+If you are [linking identities received from Verify to information in your database](LINK), you should make sure to test against potential problematic scenarios.
 
 A test identity provider contains:
 

--- a/source/technology-overview/index.html.md.erb
+++ b/source/technology-overview/index.html.md.erb
@@ -9,7 +9,7 @@ GOV.UK Verify lets users prove their identity online so they can access governme
 
 ## GOV.UK Verify hub
 
-The GOV.UK Verify hub is the infrastructure that manages interactions between users, government services, identity providers, and matching services for the purpose of authenticating a user who wants to use a government service.
+The GOV.UK Verify hub is the infrastructure that manages interactions between users, government services, and identity providers for the purpose of authenticating a user who wants to use a government service.
 
 The hub is at the centre of the GOV.UK Verify federation, providing a clear divide between identity providers and government services. This means your service has to integrate with the GOV.UK Verify hub only. It doesn’t have to integrate with several identity providers.
 
@@ -36,21 +36,9 @@ A transactional government service that needs proof of a person’s identity to 
 
 [The VSP](LINK) is a software tool provided by GOV.UK Verify. It handles communication and authentication between your service and the Verify Hub, converting the Hub’s [SAML](LINK) into JSON and vice versa, and managing much of the security.
 
-## Matching Service
-
-The function of finding a match between a user’s verified identity and a record in a government service’s data sources. The [matching service](LINK) is composed of the Matching Service Adapter (MSA) and the local matching service.
-
-## Matching Service Adapter (MSA)
-
-The [Matching Service Adapter](LINK) is a software tool provided by GOV.UK Verify. It simplifies communication between your local matching service and the GOV.UK Verify hub. The MSA converts [SAML](LINK) into JSON and vice versa.
-
-## Local Matching Service
-
-A Local Matching Service finds a match between a user’s assured identity and a record in the government service’s data sources, to allow the user to access the service. Because there’s no unique identifier for UK citizens, locating the record involves matching user information (for example name, address, date of birth) against the service’s records.
-
 ## SAML
 
-[SAML](LINK) is a data format for exchanging information securely. All exchanges between the entities in the GOV.UK Verify federation use SAML but the local matching service managed by the government service usually uses JSON.
+[SAML](LINK) is an open standard for exchanging information securely. The entities of the GOV.UK federation, the government service, GOV.UK Verify Hub, and identity providers, exchange information using SAML.
 
 For more information, see the [diagram showing the SAML message flow](LINK) within the GOV.UK Verify federation.
 

--- a/source/technology-overview/message-flow/index.html.md.erb
+++ b/source/technology-overview/message-flow/index.html.md.erb
@@ -25,7 +25,7 @@ The GOV.UK Verify hub prompts the user to select an identity provider to authent
 
 ### Step 4
 
-The identity provider then [signs](LINK) and sends a SAML response to the GOV.UK Verify hub. The SAML response contains an authentication context assertion and an identity assertion, both signed by the identity provider and [encrypted](LINK) for the GOV.UK Verify hub. The authentication context assertion validates the user’s authentication and contains the [level of assurance](LINK). The identity assertion contains the user’s [matching dataset](LINK) and the [persistent identifier](LINK).
+The identity provider then [signs](LINK) and sends a SAML response to the GOV.UK Verify hub. The SAML response contains an authentication context assertion and an identity assertion, both signed by the identity provider and [encrypted](LINK) for the GOV.UK Verify hub. The authentication context assertion validates the user’s authentication and contains the [level of assurance](LINK). The identity assertion contains the user’s identity and the [persistent identifier](LINK).
 
 ### Step 5
 

--- a/source/technology-overview/public-key-infrastructure/index.html.md.erb
+++ b/source/technology-overview/public-key-infrastructure/index.html.md.erb
@@ -58,11 +58,9 @@ Certificates are issued and signed by a certificate authority. The certificate a
 
 The IDAP PKI and GOV.UK Verify federation use the X509 standard for digital certificates.
 
-In the GOV.UK Verify federation, the IDAP certificate authority issues and signs certificates. As a government service using GOV.UK Verify, you need to request 4 certificates:
+In the GOV.UK Verify federation, the IDAP certificate authority issues and signs certificates. As a government service using GOV.UK Verify, you must request encryption and signing certificates for your service provider.
 
-* encryption and signing certificates for your service
-* encryption and signing certificates for your Matching Service Adapter
-
+If you are running the legacy setup with matching, you must also request encryption and signing certificates for your Matching Service Adapter.
 
 To obtain a certificate:
 


### PR DESCRIPTION
The PR removes occurrences of the word 'matching' in the main body of the documentation.
This change does not imply the content on these pages has been updated. The PR only removes potentially misleading terminology to provide a better user experience during research.

When reviewing, please only check for consistency within the paragraph and any glaring typos or style mistakes.