### PR TITLE
Add review dates to test the spaniel

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: GOV.UK Verify technical documentation
 weight: 1
+last_reviewed_on: 2018-12-21
+review_in: 10 days
 ---
 
 # GOV.UK Verify technical documentation


### PR DESCRIPTION
Added `last_reviewed_on` and `review_in` values to produce a page that is due for review. This is to be used for testing the integration with [Daniel the Manual Spaniel](https://github.com/alphagov/tech-docs-monitor) functionality.

The [page expiry banners are deactivated](https://github.com/alphagov/verify-tech-docs/blob/master/source/javascripts/application.js) so there will be no visual cue on the website to disrupt user experience.