### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 
 ## Getting started
 
+You can [read documentation about the GDS technical documentation
+tool][tdt-documentation] [external link].
+
 To preview or build the website, we need to use the terminal.
 
-Install Ruby with Rubygems, perferably with a [Ruby version manager][rvm],
+Install Ruby with Rubygems, preferably with a [Ruby version manager][rvm],
 and the [Bundler gem][bundler].
 
 In the application folder type the following to install the required gems:
@@ -96,3 +99,4 @@ The documentation is [© Crown copyright][copyright] and available under the ter
 [mit]: LICENCE
 [copyright]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
 [ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
+[tdt-documentation]: https://tdt-documentation.london.cloudapps.digital

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-
-**This repo is a work in progress as we migrate the [GOV.UK Verify documentation](http://alphagov.github.io/rp-onboarding-tech-docs/index.html) to the [GOV.UK tech doc tool format](https://github.com/alphagov/tech-docs-template).**
-
-
 # Technical Documentation
 
 [![Build Status](https://travis-ci.com/alphagov/verify-tech-docs.svg?branch=master)](https://travis-ci.com/alphagov/verify-tech-docs)


### PR DESCRIPTION
## Context

This repo now contains the official documentation for connecting services.

The tech writer team has written documentation for the docs tool. This documentation is now live.

## Changes proposed in this pull request

Remove the paragraph at the beginning of the README that says this is not the official documentation for connecting.

Add a link to the documentation for the docs tool in the `README.md`.