### PR TITLE
Change URLs to point to the product page, not the prototype.

### DIFF
--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -47,8 +47,8 @@
 [delete-test-users]: /test-in-integration/testing/set-up-tests/#delete-test-users
 [end-to-end-tests]: /test-in-integration/testing/run-end-to-end-tests/#run-end-to-end-tests
 
-[product page]: https://connecting-to-verify-prototype.herokuapp.com/get-started
-[support]: https://connecting-to-verify-prototype.herokuapp.com/product-page/support
+[product page]: https://www.verify.service.gov.uk/
+[support]: https://www.verify.service.gov.uk/support/
 [saml]: /technology-overview/saml/#saml
 [saml-spec]: https://www.gov.uk/government/publications/identity-assurance-hub-service-saml-20-profile
 [message-flow]: /technology-overview/message-flow


### PR DESCRIPTION
URLs to the product page and the support section on the product page link to the Heroku prototype.

This PR is to change them to the ones for the live website.