### PR TITLE
Mention page about failure responses where relevant

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -14,10 +14,10 @@ The Verify Service Provider (VSP) allows you to send and receive messages from t
 
 The first step in connecting to GOV.UK Verify is to set up the VSP locally. You must host the VSP on your own infrastructure and you can connect multiple services to one instance.
 
-[Follow the step-by-step guide][tutorial] to make sure your service correctly uses the VSP to:
+Follow the step-by-step guides in this section to make sure your service correctly uses the VSP to handle:
 
-- generate and send authentication requests
-- handle the successful verification response
+- [successful verification responses][vsp-guide-success]
+- [possible failure scenarios][vsp-guide-failure]
 
 Once you've confirmed your service can handle all the possible response scenarios, you can move on to testing your setup in [the secure test environment](access-integration) which contains a full-scale deployment of the GOV.UK Verify Hub.
 

--- a/source/get-started/set-up-successful-verification-journey/index.html.md.erb
+++ b/source/get-started/set-up-successful-verification-journey/index.html.md.erb
@@ -213,4 +213,8 @@ For a successful verification journey, the response body contains:
 
 Your service can use this identity dataset to guide a user with their service journey.
 
+## Next Steps
+
+Now that your service can handle the successful verification user journey, make sure your service can [handle possible failure scenarios][vsp-guide-failure].
+
 <%= partial "partials/links" %>

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -1,9 +1,11 @@
 
 [status]: https://verifystatus.digital.cabinet-office.gov.uk/
 
-[tutorial]: /get-started/set-up-successful-verification-journey
 [vsp-guide-success]: /get-started/set-up-successful-verification-journey
-[vsp-guide-failure]: https://www.docs.verify.service.gov.uk/get-started/handle-failure-scenarios
+[vsp-guide-request]: /get-started/set-up-successful-verification-journey/#send-a-request
+[vsp-guide-response]: /get-started/set-up-successful-verification-journey/#handle-a-response
+
+[vsp-guide-failure]: /get-started/handle-failure-scenarios
 
 [loa]: https://www.verify.service.gov.uk/understand-levels-of-assurance/
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -2,6 +2,8 @@
 [status]: https://verifystatus.digital.cabinet-office.gov.uk/
 
 [tutorial]: /get-started/set-up-successful-verification-journey
+[vsp-guide-success]: /get-started/set-up-successful-verification-journey
+[vsp-guide-failure]: https://www.docs.verify.service.gov.uk/get-started/handle-failure-scenarios
 
 [loa]: https://www.verify.service.gov.uk/understand-levels-of-assurance/
 

--- a/source/plan-your-connection/development-steps/index.html.md.erb
+++ b/source/plan-your-connection/development-steps/index.html.md.erb
@@ -15,8 +15,8 @@ When your service can successfully handle all the responses form the GOV.UK Veri
 
 ### Set up your Verify Service Provider
 
-1. [Send an authentication request to the GOV.UK Verify hub][tutorial].
-1. [Handle the response from the GOV.UK Verify hub][tutorial].
+1. [Send an authentication request to the GOV.UK Verify hub][vsp-guide-request].
+1. [Handle the response from the GOV.UK Verify hub][vsp-guide-response].
 
 Outcome: you’re ready to run SAML compliance tests.
 


### PR DESCRIPTION
## Background

A new page about handling failure responses was published: https://www.docs.verify.service.gov.uk/get-started/handle-failure-scenarios

This new page should be mentioned on:

- the [Get started](https://www.docs.verify.service.gov.uk/get-started) section cover page.
- the [Set up the successful verification journey](https://www.docs.verify.service.gov.uk/get-started/set-up-successful-verification-journey) page as the next step in setting up the VSP

## Changes

- Add link to the [page about handling failure responses](https://www.docs.verify.service.gov.uk/get-started/handle-failure-scenarios) on:
 - the [section cover page](https://www.docs.verify.service.gov.uk/get-started)
 - the [Set up the successful verification journey](https://www.docs.verify.service.gov.uk/get-started/set-up-successful-verification-journey) page as the next step in setting up the VSP

- Change link labels for the two guides to: `[vsp-guide-success]` and `[vsp-guide-failure]` to make them more descriptive.

- Update link labels across the docs to ensure the new labels don't break any links