### PR TITLE
Remove [external link] labels

### DIFF
--- a/source/get-started/handle-failure-scenarios/index.html.md.erb
+++ b/source/get-started/handle-failure-scenarios/index.html.md.erb
@@ -27,7 +27,7 @@ The guide uses a GOV.UK Verify-hosted testing service as a placeholder for the G
 
 To follow instructions on this page, you must have already:
 
-- downloaded [the latest VSP release][vsp-release] [external link]
+- downloaded [the latest VSP release][vsp-release] from GitHub
 - familiarised yourself with or implemented [the successful verification scenario][successful-verification]
 
 This guide continues from the ['Response from the testing service' section][response-from-testing-service].

--- a/source/get-started/set-up-successful-verification-journey/index.html.md.erb
+++ b/source/get-started/set-up-successful-verification-journey/index.html.md.erb
@@ -18,7 +18,7 @@ The guide uses a GOV.UK Verify-hosted testing service as a placeholder for the G
 
 ## Before you start
 
-You need VSP 2.0.0 or above to follow instructions on this page. See [the latest VSP release][vsp-release] [external link].
+You need VSP 2.0.0 or above to follow instructions on this page. See [the latest VSP release][vsp-release] on GitHub.
 
 ## Using the VSP with the testing service
 
@@ -30,7 +30,7 @@ To connect your VSP to the testing service, start the VSP using the `development
 
 The example sets `http://localhost:8080` as the endpoint where the testing service sends the SAML responses.
 
-Read more about the development command and other [commands available for the VSP][vsp-run] [external link] in the VSP's README file.
+Read more about the development command and other [commands available for the VSP][vsp-run] in the VSP's README file on GitHub.
 
 ## Send a request
 
@@ -73,7 +73,7 @@ You must store the `requestId` securely and link it to the user's session. For e
 
 ### Send the authentication request to the testing service
 
-After receiving the authentication request, your service sends that request to the testing service through the browser. To do this, render an HTML form containing JavaScript to auto-submit the form, as described by [SAML HTTP Post Binding](https://en.wikipedia.org/wiki/SAML_2.0#HTTP_POST_Binding) [external link]:
+After receiving the authentication request, your service sends that request to the testing service through the browser. To do this, render an HTML form containing JavaScript to auto-submit the form, as described by [SAML HTTP Post Binding](https://en.wikipedia.org/wiki/SAML_2.0#HTTP_POST_Binding):
 
 ```html
 <!-- The form containing the SAML authentication request


### PR DESCRIPTION
### Context

The [content design guidance on links](https://www.gov.uk/guidance/content-design/links) no longer requires `[external link]` labelling of linked text leading outside of the trusted `.gov.uk` domain.

This is great because these `[external link]` labels make the content look messy and unfinished, which is potentially damaging users' trust in the content.

We still have to make sure it's obvious to the user when they leave the `.gov.uk` domain.

### Changes

Remove `[external link]` labels.

Add clarification where needed, for example 'on GitHub', for links leading to GitHub.

No clarification added to the link to Wikipedia because it is disruptive to the flow. Because of the recognisable Wikipedia branding, there is no reason documentation users will be confused and believe they're still on `docs.verify.service.gov.uk`. 