### PR TITLE
Mention creating records as a use case

### DIFF
--- a/source/using-verify-data/index.html.md.erb
+++ b/source/using-verify-data/index.html.md.erb
@@ -10,8 +10,9 @@ When an identity provider successfully verifies a user’s identity, the respons
 Your use case for this information depends on your service's needs. You might need to:
 
 - link the user information with user data your service already holds
-- store information as part of an audit requirement
+- store the information as part of an audit requirement
 - forward it to a case worker
+- use the information create a new records
 
 <newline>
 

--- a/source/using-verify-data/index.html.md.erb
+++ b/source/using-verify-data/index.html.md.erb
@@ -12,7 +12,7 @@ Your use case for this information depends on your service's needs. You might ne
 - link the user information with user data your service already holds
 - store the information as part of an audit requirement
 - forward it to a case worker
-- use the information create a new records
+- use the information to create new records
 
 <newline>
 


### PR DESCRIPTION
The product page says "you can use the information provided by the identity providers to create a new database for matching identities or auditing purposes."

The docs don't mention using the data to create a new database or add records to an existing one:

![image](https://user-images.githubusercontent.com/17963330/56129711-c1961c80-5f7a-11e9-81f7-32147ce33b94.png)


This PR adds a bullet point mentioning new record creation as a use case.

https://www.verify.service.gov.uk/how-verify-works/