### PR TITLE
Add review dates

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -45,4 +45,4 @@ api_path:
 
 # Set default slack workspace and owner
 owner_slack_workspace: gds
-default_owner_slack: '#bot-testing'
+default_owner_slack: '#verify-developers'

--- a/source/development-steps/index.html.md.erb
+++ b/source/development-steps/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Development steps
 weight: 15
+last_reviewed_on: 2019-04-12
+review_in: 4 months
 ---
 
 # Development steps

--- a/source/using-verify-data/about-matching/index.html.md.erb
+++ b/source/using-verify-data/about-matching/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Introduction to matching
 weight: 20
+last_reviewed_on: 2019-04-12
+review_in: 6 months
 ---
 
 # Introduction to matching

--- a/source/using-verify-data/data-from-verify/index.html.md.erb
+++ b/source/using-verify-data/data-from-verify/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Data from GOV.UK Verify
 weight: 10
+last_reviewed_on: 2019-04-12
+review_in: 6 months
 ---
 
 # Data from GOV.UK Verify

--- a/source/using-verify-data/evaluate-datasources/index.html.md.erb
+++ b/source/using-verify-data/evaluate-datasources/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Evaluate datasources
 weight: 30
+last_reviewed_on: 2019-04-12
+review_in: 6 months
 ---
 
 # Evaluate datasources

--- a/source/using-verify-data/index.html.md.erb
+++ b/source/using-verify-data/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Decide how to use GOV.UK Verify data
 weight: 20
+last_reviewed_on: 2019-04-12
+review_in: 6 months
 ---
 
 # Decide how to use data from GOV.UK Verify

--- a/source/using-verify-data/matching-strategy/index.html.md.erb
+++ b/source/using-verify-data/matching-strategy/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Matching strategy
 weight: 40
+last_reviewed_on: 2019-04-12
+review_in: 6 months
 ---
 
 # Matching strategy

--- a/source/using-verify-data/prepare-local-datasource/index.html.md.erb
+++ b/source/using-verify-data/prepare-local-datasource/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Prepare local datasources
 weight: 50
+last_reviewed_on: 2019-04-12
+review_in: 6 months
 ---
 
 # Prepare local datasources


### PR DESCRIPTION
### Background

We've enabled [Daniel the Manual Spaniel][daniel] for these docs so we should add review dates for pages after they're re-written. We recently [re-written pages][move-matching] on development steps and deciding how to use the data from identity providers, but haven't added review dates.

We agreed in the Verify Firebreak Show and Tell of January 2019 to have `#verify-developers` as the default Slack owner for the docs. The page expiry banners are disabled for these docs so setting the slack owner only has implications for Daniel the Manual Spaniel. Daniel will start messaging `#verify-developers` when a page is due for review.

### Changes

#### Add review dates

Fill in review dates for: 
* the guidance pages on matching and data from identity providers (in 6 months)
* the development steps page (in 4 months)

#### Set Slack owner
Set `#verify-developers` as the the default slack owner for tech docs.

[daniel]: https://github.com/alphagov/tech-docs-monitor/blob/dacb7cce687cb5b94fa3516828a812566b72f5fd/.travis.yml#L9
[move-matching]: https://github.com/alphagov/verify-tech-docs/pull/37