### PR TITLE
Migrate Verify Tech Docs to cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ applications:
   buildpacks:
     - staticfile_buildpack
   instances: 2
+  stack: cflinuxfs3


### PR DESCRIPTION
Add `stack: cflinuxfs3` to manifest.yml

The Verify Tech Docs are being deployed on cflinuxfs2 in PaaS. cflinuxfs2 is being deprecated in April, 2019. Cflinuxfs2 is based on Ubuntu 14.04 (Trusty), whilst cflinuxfs3 is based on Ubuntu 18.04 (Bionic). This upgrade is taking place because, at the end of April 2019, Canonical will cease support for Ubuntu 14.04, meaning it will no longer receive security updates. PaaS team is planning to remove the old stack cflinuxfs2 on 24th April 2019.

Sources: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!topic/gov-uk-paas-announce/B2m3Ek8aakM