### PR TITLE
Remove mention of compliance tool tests when accessing Integration

### DIFF
--- a/source/test-in-integration/index.html.md.erb
+++ b/source/test-in-integration/index.html.md.erb
@@ -11,7 +11,10 @@ The purpose of the integration environment is to make sure that your service ope
 
 ## What do you need to do?
 
-Before you access the Integration environment, you should make sure your service passes [compliance tool tests][compliance-tool].
+Before you access the Integration environment, you should make sure your service can handle:
+
+* [the successful verification scenario][vsp-guide-success]
+* [all the failure scenarios][vsp-guide-failure]
 
 To access the Integration environment:
 


### PR DESCRIPTION
The Compliance Tool functionality is now part of the VSP.

The requirement to pass those tests is now equivalent to the service 
being able to handle the successful verification and the failure 
scenarios.