### PR TITLE
Fix "persistent identifier" link that did not go anywhere

### DIFF
--- a/source/technology-overview/message-flow/index.html.md.erb
+++ b/source/technology-overview/message-flow/index.html.md.erb
@@ -25,7 +25,7 @@ The GOV.UK Verify hub prompts the user to select an identity provider to authent
 
 ### Step 4
 
-The identity provider then signs and sends a SAML response to the GOV.UK Verify hub. The SAML response contains an authentication context assertion and an identity assertion, both signed by the identity provider and encrypted for the GOV.UK Verify hub. The authentication context assertion validates the user’s authentication and contains the [level of assurance][loa]. The identity assertion contains the user’s identity and the [persistent identifier]().
+The identity provider then signs and sends a SAML response to the GOV.UK Verify hub. The SAML response contains an authentication context assertion and an identity assertion, both signed by the identity provider and encrypted for the GOV.UK Verify hub. The authentication context assertion validates the user’s authentication and contains the [level of assurance][loa]. The identity assertion contains the user’s identity and the [persistent identifier][pid].
 
 ### Step 5
 


### PR DESCRIPTION
The "persistent identifier" link in [this paragraph](https://www.docs.verify.service.gov.uk/technology-overview/message-flow/#step-4) does not go anywhere.

This now links to /using-verify-data/data-from-verify/#persistent-identifier within the tech docs.