### PR TITLE
Fix broken link in matching strategy section

### DIFF
--- a/source/using-verify-data/matching-strategy/index.html.md.erb
+++ b/source/using-verify-data/matching-strategy/index.html.md.erb
@@ -177,7 +177,7 @@ If you cannot find a match with the postcode, you can:
 - ignore it, try to get sufficient matches on other attributes and move to the user input match for disambiguation
 - ask the user to provide further attributes to be able to use the user input match
 
-If you choose to request other attributes from the user to do a [user input match][user-input-match], you should consider how best to capture the information. For example, whether to ask a user to return online and provide more information or if someone from your organisation can collect the information in a telephone call.
+If you choose to request other attributes from the user to do a [user input match][attributes-from-user], you should consider how best to capture the information. For example, whether to ask a user to return online and provide more information or if someone from your organisation can collect the information in a telephone call.
 
 ### Build confidence in a single record
 


### PR DESCRIPTION
The markdown was not resolving the link and now resolves to https://www.docs.verify.service.gov.uk/using-verify-data/matching-strategy/#matching-using-input-from-the-user.