### PR TITLE
Fix link to "secure test environment" on Get started page

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -19,7 +19,7 @@ Follow the step-by-step guides in this section to make sure your service correct
 - [successful verification responses][vsp-guide-success]
 - [possible failure scenarios][vsp-guide-failure]
 
-Once you've confirmed your service can handle all the possible response scenarios, you can move on to testing your setup in [the secure test environment](access-integration) which contains a full-scale deployment of the GOV.UK Verify Hub.
+Once you've confirmed your service can handle all the possible response scenarios, you can move on to testing your setup in [the secure test environment][about-integration] which contains a full-scale deployment of the GOV.UK Verify Hub.
 
 If you are thinking of not using the VSP, [contact the GOV.UK Verify team][support] before you start building your own service provider.
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -51,6 +51,7 @@
 
 [decide-data]: /using-verify-data/#decide-how-to-use-gov-uk-verify-data
 
+[about-integration]: /test-in-integration
 [requesters-and-approvers]: /test-in-integration/get-certificates/#name-your-certificate-requesters-and-approvers
 [ncsc]: https://www.ncsc.gov.uk
 [create-test-users]: /test-in-integration/testing/set-up-tests/#create-test-users


### PR DESCRIPTION
- create new link label
- add new link label instad of broken link text