### PR TITLE
Add step saying to wait for deployment confirmation

### DIFF
--- a/source/maintain-your-connection/rotate-keys/index.html.md.erb
+++ b/source/maintain-your-connection/rotate-keys/index.html.md.erb
@@ -134,6 +134,8 @@ The MSA publishes its certificates containing the public keys in its own metadat
 
     If you’re using the VSP, wait for it to load the MSA metadata. The VSP periodically refreshes its metadata and will log when it has finished. Once it loads the new metadata, the VSP trusts assertions signed with the new MSA signing key.
 
+1. Receive confirmation from the GOV.UK Verify team that they have deployed your new MSA signing certificate.
+
 1. Delete the `signingKeys.primary` section and rename `signingKeys.secondary` to `signingKeys.primary` - the MSA now signs the assertions with the new  key.
 
 1. Restart the MSA to update its metadata to contain only the new signing certificate.


### PR DESCRIPTION
# Context

The instructions for rotating the MSA signing key do not mention waiting for confirmation from the Verify team.

# This is important because

It's crucial that services wait for confirmation that their new signing certificate has been deployed.
If services proceed to the next step (deleting the old signing key and cert) before receiving confirmation from Verify, the connection breaks because the Hub can't recognise the service's new signature.

# Change proposed

Add a step to ensure service teams receive the confirmation email before deleting the old key and cert.