### PR TITLE
Delete reference to non-existent figure

### DIFF
--- a/source/test-in-integration/testing/index.html.md.erb
+++ b/source/test-in-integration/testing/index.html.md.erb
@@ -13,8 +13,5 @@ You must provide a full demonstration of all user journeys as part of your [Stag
 
 > If you carry out penetration testing (pen testing) on your end-to-end system, you must not extend this to the hub domain. You must only run penetration tests on your own system. If you think you have a valid reason for running penetration tests in the hub domain, you must first contact GOV.UK Verify support at idasupport+onboarding@digital.cabinet-office.gov.uk.
 
-This diagram shows the end-to-end testing flow. See below for explanations.
-
-[figure]
 
 <%= partial "partials/links" %>


### PR DESCRIPTION
At the bottom of the "Testing in Integration" page there is a reference to a non-existent image:

![image](https://user-images.githubusercontent.com/53218029/62297336-ee5a3b00-b468-11e9-8f9c-be75afcfe9cc.png)

Unless there's an image to put in here, we should delete the text referring to it.