### PR TITLE
Improve content about security incident recommendations

### DIFF
--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -18,11 +18,18 @@ You must stop using the compromised keys as soon as possible. The quickest way t
 
 ## If you uploaded the wrong encryption certificate
 
-Your connection to GOV.UK Verify can break if you upload the wrong certificate to the GOV.UK Verify Self Service Admin tool.
+Your connection to GOV.UK Verify will break if you upload an encryption certificate that doesn’t match any of your private encryption keys. This is because your component won’t be able to use the private encryption keys to decrypt messages from the GOV.UK Verify Hub.
 
-If you've uploaded the wrong certificate to the GOV.UK Verify Self Service Admin tool, replace it by uploading the correct certificate.
+To restore your connection to GOV.UK Verify, replace the wrong certificate by [uploading the encryption certificate][manage-certs] corresponding to your new encryption key.
 
-Make sure the new certificate matches its corresponding private key in your configuration.
 ## If you uploaded the wrong signing certificate
+
+
+If you uploaded a signing certificate that doesn’t match your new private signing key, you must remove that certificate from the GOV.UK Verify Manage certificates service and then upload the correct one.
+
+1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+2. Select the signing certificate that doesn’t match your new private key.
+3. Select **Stop using this certificate**.
+4. Upload the correct cert using the [GOV.UK Verify Manage certificates service][manage-certs]
 
 <%= partial "partials/links" %>

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -11,12 +11,10 @@ This page has guidance about what to do in situations that can break or compromi
 
 If you have reasons to believe that any of the private keys securing your connection to GOV.UK Verify have been compromised, you are having a security incident. In addition to following your organisation's procedure, you must:
 
-1. [Replace the compromised keys][rotate-keys] immediately.
-2. [Contact the Verify team][support] to let them know of the incident.
+* [replace the compromised keys][rotate-keys] immediately
+* [let the GOV.UK Verify team know][support] so they can help reduce the impact of the incident and run appropriate fraud and security checks
 
-You need to stop using the compromised keys as soon as possible. The quickest way to do this is by changing them using the [GOV.UK Verify Self-Service Admin tool][manage-certs].
-
-You must let the GOV.UK Verify team know if private keys securing your connection to GOV.UK Verify are compromised so they can run the appropriate fraud and security checks.
+You need to stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
 
 ## When uploading the wrong certificate
 

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 65
 
 This page has guidance about what to do in situations that can break or compromise your service's connection to GOV.UK Verify.
 
-## Handle a private key leak
+## If there is a private key leak
 
 If you have reasons to believe that any of the private keys securing your connection to GOV.UK Verify have been compromised, you are having a security incident. In addition to following your organisation's procedure, you must:
 
@@ -16,12 +16,13 @@ If you have reasons to believe that any of the private keys securing your connec
 
 You need to stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
 
-## When uploading the wrong certificate
+## If you uploaded the wrong encryption certificate
 
 Your connection to GOV.UK Verify can break if you upload the wrong certificate to the GOV.UK Verify Self Service Admin tool.
 
 If you've uploaded the wrong certificate to the GOV.UK Verify Self Service Admin tool, replace it by uploading the correct certificate.
 
 Make sure the new certificate matches its corresponding private key in your configuration.
+## If you uploaded the wrong signing certificate
 
 <%= partial "partials/links" %>

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -9,12 +9,12 @@ This page has guidance about what to do in situations that can break or compromi
 
 ## If there is a private key leak
 
-If you have reasons to believe that any of the private keys securing your connection to GOV.UK Verify have been compromised, you are having a security incident. In addition to following your organisation's procedure, you must:
+If any of the private keys securing your connection to GOV.UK Verify have been compromised, you are having a security incident. In addition to following your organisation's procedure, you must:
 
 * [replace the compromised keys][rotate-keys] immediately
-* [let the GOV.UK Verify team know][support] so they can help reduce the impact of the incident and run appropriate fraud and security checks
+* [let the GOV.UK Verify team know][support] so they can help reduce the impact of the incident and run fraud and security checks
 
-You need to stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
+You must stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
 
 ## If you uploaded the wrong encryption certificate
 


### PR DESCRIPTION
## Changes proposed

Change bulleted list to numbered list because the order is not crucial - 
both things need to happen as soon as possible.

Say that the Verify team can help reduce the impact of the incident.

Fix phrasing to say you need to rotate keys and certs if your keys are 
compromised.

Refer to the thing as 'GOV.UK Verify Manage certificates service'

## How to review

**Tech team member:** check for factual accuracy
**Technical writer:** readability and GOV.UK style