### PR TITLE
New text on rotations being independent and different

### DIFF
--- a/source/rotating-your-keys-and-certificates/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/index.html.md.erb
@@ -7,6 +7,8 @@ weight: 60
 
 When the certificates containing your public keys are due to expire, you must update them. If you don't, your users won't be able to access your service using GOV.UK Verify.
 
+Certificate updates are independent of each other, so you can update more than one certificate at the same time. You need to follow a different process for each type of certificate.
+
 As a government service you are responsible for maintaining the encryption and signing keys and certificates for your service provider and Matching Service Adapter (MSA), if you are running one. Your service provider could be the [Verify Service Provider (VSP)][vsp-github] or another service provider.
 
 <%= partial "partials/links" %>


### PR DESCRIPTION
The recent user research raised that users are unsure if:

- they need to wait for each certificate rotation to finish before starting another
- the process for rotating certificates are different

I have added text to emphasise that certificate rotations are independent and that each process is different.

