### PR TITLE
Add Troubleshooting section

### DIFF
--- a/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
+++ b/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
@@ -10,15 +10,17 @@ These steps will help you find out:
 * what caused your connection to break during the key rotation
 * how to restore your connection
 
-## 1. Restart your component
+## Step 1. Restart your component
 
 Make sure your component is using the new key, and certificate, if applicable. For example, you must restart the Verify Service Provider after a configuration change for it to start using the new key.
 
-## 2. Apply configuration changes to all instances
+## Step 2. Apply changes to all instances
 
 Make sure you restart all instances of the component you're doing the key rotation for. This ensures all instances are using the new keys in their configuration.
 
-## 3. Check that the uploaded certificate is the right one
+## Step 3. Check the uploaded certificate
+
+is the right one
 
 1. Go to the [GOV.UK Verify Manage certificates service][manage-certs].
 2. Select the certificate you want to investigate.
@@ -32,7 +34,7 @@ For example, you should check:
 
 ### If the uploaded certificate is the right one
 
-If the information in the **Common name** matches the environment and component of the uploaded certificate, go to [Step 4][troubleshooting-4] to continue troubleshooting your connection.
+If the information in the **Common name** matches the environment, component, and type of uploaded certificate, go to [Step 4. Check the uploaded certificate matches your new key][troubleshooting-4] to continue troubleshooting your connection.
 
 ### If you uploaded the wrong encryption certificate
 
@@ -59,9 +61,9 @@ If you uploaded a signing certificate that doesn’t match your new private sign
 If you don't have the right certificate, [start a new key rotation process][rotating-keys-certs].
 
 
-## 4. Check that the uploaded certificate matches your new key
+## Step 4. Check the uploaded certificate matches your new key
 
-If the uploaded certificate you checked in Step 3 is the right one, you should make sure it matches the new private key your component is using.
+If the uploaded certificate you checked in [Step 3 Check the uploaded certificate][troubleshooting-3] is the right one, you should make sure it matches the new private key your component is using.
 
 For example, you can use `openssl` to check if the certificate you uploaded matches the new private key your component is using. A private key matches a certificate if their 'modulus' sections are identical. Create an MD5 hash for the modulus if you are comparing the output strings by eye.
 

--- a/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
+++ b/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
@@ -20,21 +20,15 @@ Make sure you restart all instances of the component you're doing the key rotati
 
 ## Step 3. Check the uploaded certificate
 
-is the right one
+Check the details of certificate you last uploaded to the [GOV.UK Verify Manage certificates service][manage-certs]. The **Common name** of the certificate should have information about the intended use for the certificate. Use this information to check that the certificate is:
 
-1. Go to the [GOV.UK Verify Manage certificates service][manage-certs].
-2. Select the certificate you want to investigate.
-3. Use the certificate details to figure out if this is the certificate you intended to use.
-
-For example, you should check:
-
-* that the certificate was uploaded to the correct component
-* **Common name** for information about the intended use for the certificate
-* **Environment** to see which GOV.UK Verify environment uses your certificate
+* linked to the right component
+* in the right GOV.UK Verify environment, for example Integration or Production
+* of the correct type, for example signing or encryption
 
 ### If the uploaded certificate is the right one
 
-If the information in the **Common name** matches the environment, component, and type of uploaded certificate, go to [Step 4. Check the uploaded certificate matches your new key][troubleshooting-4] to continue troubleshooting your connection.
+If the information in the **Common name** matches the details of the uploaded certificate, go to [Step 4. Check the uploaded certificate matches your new key][troubleshooting-4] to continue troubleshooting your connection.
 
 ### If you uploaded the wrong encryption certificate
 

--- a/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
+++ b/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
@@ -12,7 +12,7 @@ These steps will help you find out:
 
 ## Step 1. Restart your component
 
-Make sure your component is using the new key, and certificate, if applicable. For example, you must restart the Verify Service Provider after a configuration change for it to start using the new key.
+You must restart your component after making a configuration change so it starts using the new configuration. For example, you must restart the Verify Service Provider for it to start using the new key.
 
 ## Step 2. Apply changes to all instances
 
@@ -20,52 +20,52 @@ Make sure you restart all instances of the component you're doing the key rotati
 
 ## Step 3. Check the uploaded certificate
 
-Check the details of certificate you last uploaded to the [GOV.UK Verify Manage certificates service][manage-certs]. The **Common name** of the certificate should have information about the intended use for the certificate. Use this information to check that the certificate is:
+Check the details of the certificate you last uploaded to the [GOV.UK Verify Manage certificates service][manage-certs]. The **Common name** of the certificate should have information about the intended use for the certificate. Use this information to check that the certificate is:
 
-* linked to the right component
-* in the right GOV.UK Verify environment, for example Integration or Production
+* linked to the correct component
+* in the correct GOV.UK Verify environment, for example Integration or Production
 * of the correct type, for example signing or encryption
 
-### If the uploaded certificate is the right one
+### If you uploaded the correct certificate
 
 If the information in the **Common name** matches the details of the uploaded certificate, go to [Step 4. Check the uploaded certificate matches your new key][troubleshooting-4] to continue troubleshooting your connection.
 
 ### If you uploaded the wrong encryption certificate
 
-Your connection to GOV.UK Verify will break if you upload an encryption certificate that doesn’t match any of your private encryption keys. This is because your component won’t be able to use the private encryption keys to decrypt messages from the GOV.UK Verify Hub.
+Your connection to GOV.UK Verify will break if you upload an encryption certificate that does not match any of your private encryption keys. This is because your component will not be able to use the private encryption keys to decrypt messages from the GOV.UK Verify Hub.
 
 To restore your connection to GOV.UK Verify, replace the wrong certificate with the correct one.
 
 1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-2. Select the encryption certificate that doesn’t match your new private key.
+2. Select the encryption certificate that does not match your new private key.
 3. Select **Replace certificate** and follow the instructions.
 
 
 ### If you uploaded the wrong signing certificate
 
-If you uploaded a signing certificate that doesn’t match your new private signing key, you must remove that certificate from the GOV.UK Verify Manage certificates service and then upload the correct one.
+If you uploaded a signing certificate that does not match your new private signing key, you must remove that certificate from the GOV.UK Verify Manage certificates service and then upload the correct one.
 
 1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-2. Select the signing certificate that doesn’t match your new private key.
+2. Select the signing certificate that does not match your new private key.
 3. Select **Stop using this certificate**.
 4. Upload the correct certificate using the [GOV.UK Verify Manage certificates service][manage-certs].
 
-### If you don't have the right certificate
+### If you do not have the correct certificate
 
-If you don't have the right certificate, [start a new key rotation process][rotating-keys-certs].
+If you do not have the correct certificate, [start a new key rotation process][rotating-keys-certs].
 
 
 ## Step 4. Check the uploaded certificate matches your new key
 
-If the uploaded certificate you checked in [Step 3 Check the uploaded certificate][troubleshooting-3] is the right one, you should make sure it matches the new private key your component is using.
+If the uploaded certificate you checked in [Step 3 Check the uploaded certificate][troubleshooting-3] is the correct one, make sure it matches the new private key your component is using.
 
-For example, you can use `openssl` to check if the certificate you uploaded matches the new private key your component is using. A private key matches a certificate if their 'modulus' sections are identical. Create an MD5 hash for the modulus if you are comparing the output strings by eye.
+For example, you can use `openssl` to check if the certificate you uploaded matches the new private key your component is using. A private key matches a certificate if their 'modulus' sections are identical. If you’re not automating the comparison, it’s useful to shorten the modulus by creating an MD5 hash.
 
 ```sh
 openssl x509 -noout -modulus -in <certificate>.crt | openssl md5
 openssl rsa -noout -modulus -in <private-key>.key | openssl md5
 ```
 
-If the private key and certificate don't match, you should replace the private key with the correct match. If the correct match is not available or has been compromised, [start a new key rotation process][rotating-keys-certs].
+If the private key and certificate do not match, replace the private key with the correct match. If the correct match is not available or has been compromised, [start a new key rotation process][rotating-keys-certs].
 
 <%= partial "partials/links" %>

--- a/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
+++ b/source/emergency-procedures/broken-connection-during-rotation/index.html.md.erb
@@ -1,0 +1,75 @@
+---
+title: Broken connection during key rotation
+weight: 20
+---
+
+# Broken connection during key rotation
+
+These steps will help you find out:
+
+* what caused your connection to break during the key rotation
+* how to restore your connection
+
+## 1. Restart your component
+
+Make sure your component is using the new key, and certificate, if applicable. For example, you must restart the Verify Service Provider after a configuration change for it to start using the new key.
+
+## 2. Apply configuration changes to all instances
+
+Make sure you restart all instances of the component you're doing the key rotation for. This ensures all instances are using the new keys in their configuration.
+
+## 3. Check that the uploaded certificate is the right one
+
+1. Go to the [GOV.UK Verify Manage certificates service][manage-certs].
+2. Select the certificate you want to investigate.
+3. Use the certificate details to figure out if this is the certificate you intended to use.
+
+For example, you should check:
+
+* that the certificate was uploaded to the correct component
+* **Common name** for information about the intended use for the certificate
+* **Environment** to see which GOV.UK Verify environment uses your certificate
+
+### If the uploaded certificate is the right one
+
+If the information in the **Common name** matches the environment and component of the uploaded certificate, go to [Step 4][troubleshooting-4] to continue troubleshooting your connection.
+
+### If you uploaded the wrong encryption certificate
+
+Your connection to GOV.UK Verify will break if you upload an encryption certificate that doesn’t match any of your private encryption keys. This is because your component won’t be able to use the private encryption keys to decrypt messages from the GOV.UK Verify Hub.
+
+To restore your connection to GOV.UK Verify, replace the wrong certificate with the correct one.
+
+1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+2. Select the encryption certificate that doesn’t match your new private key.
+3. Select **Replace certificate** and follow the instructions.
+
+
+### If you uploaded the wrong signing certificate
+
+If you uploaded a signing certificate that doesn’t match your new private signing key, you must remove that certificate from the GOV.UK Verify Manage certificates service and then upload the correct one.
+
+1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+2. Select the signing certificate that doesn’t match your new private key.
+3. Select **Stop using this certificate**.
+4. Upload the correct certificate using the [GOV.UK Verify Manage certificates service][manage-certs].
+
+### If you don't have the right certificate
+
+If you don't have the right certificate, [start a new key rotation process][rotating-keys-certs].
+
+
+## 4. Check that the uploaded certificate matches your new key
+
+If the uploaded certificate you checked in Step 3 is the right one, you should make sure it matches the new private key your component is using.
+
+For example, you can use `openssl` to check if the certificate you uploaded matches the new private key your component is using. A private key matches a certificate if their 'modulus' sections are identical. Create an MD5 hash for the modulus if you are comparing the output strings by eye.
+
+```sh
+openssl x509 -noout -modulus -in <certificate>.crt | openssl md5
+openssl rsa -noout -modulus -in <private-key>.key | openssl md5
+```
+
+If the private key and certificate don't match, you should replace the private key with the correct match. If the correct match is not available or has been compromised, [start a new key rotation process][rotating-keys-certs].
+
+<%= partial "partials/links" %>

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 65
 
 # Emergency procedures
 
-This section has guidance about what to do in situations when your connection to GOV.Uk Verify is broken or compromised.
+This section has guidance about what to do in situations when your connection to GOV.UK Verify is broken or compromised.
 
 Find out what to do in case of a:
 

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -51,7 +51,13 @@ If the uploaded certificate is the wrong one, you can replace it with the right 
 
 Your connection to GOV.UK Verify will break if you upload an encryption certificate that doesn’t match any of your private encryption keys. This is because your component won’t be able to use the private encryption keys to decrypt messages from the GOV.UK Verify Hub.
 
-To restore your connection to GOV.UK Verify, replace the wrong certificate by [uploading the encryption certificate][manage-certs] corresponding to your new encryption key.
+To restore your connection to GOV.UK Verify, replace the wrong certificate with the correct one.
+
+1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+2. Select the encryption certificate that doesn’t match your new private key.
+3. Select **Replace certificate** and follow the instructions.
+
+by [uploading the encryption certificate][manage-certs] corresponding to your new encryption key.
 
 #### If you uploaded the wrong signing certificate
 
@@ -60,7 +66,7 @@ If you uploaded a signing certificate that doesn’t match your new private sign
 1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
 2. Select the signing certificate that doesn’t match your new private key.
 3. Select **Stop using this certificate**.
-4. Upload the correct cert using the [GOV.UK Verify Manage certificates service][manage-certs].
+4. Upload the correct certificate using the [GOV.UK Verify Manage certificates service][manage-certs].
 
 
 ### 4. Check that the uploaded certificate matches your new key

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -16,20 +16,64 @@ If any of the private keys securing your connection to GOV.UK Verify have been c
 
 You must stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
 
-## If you uploaded the wrong encryption certificate
+## If your connection breaks during a rotation
+
+These steps will help you find out:
+
+* what caused your connection to break during the rotation
+* how to restore your connection
+
+### 1. Restart your component
+
+Make sure your component is using the new key, and certificate, if applicable. For example, you must restart the Verify Service Provider after a configuration change for it to start using the new key.
+
+### 2. Apply configuration changes to all instances
+
+Make sure you restart all instances of the component you're doing the rotation for. This ensures all instances are using the new keys in their configuration.
+
+### 3. Check that the uploaded certificate is the right one
+
+1. Go to the [GOV.UK Verify Manage certificates service][manage-certs].
+2. Select the certificate you want to investigate.
+3. Use the certificate details to figure out if this is the certificate you intended to use.
+
+For example, you should check:
+
+* that the certificate was uploaded to the correct component
+* **Common name** for information about the intended use for the certificate
+* **Environment** to see which GOV.UK Verify environment uses your certificate
+
+If the uploaded certificate is the right certificate, go to [Step 4][troubleshooting-4] to continue troubleshooting your connection.
+
+If the uploaded certificate is the wrong one, you can replace it with the right one. If you don't have the right certificate, start the rotation from the beginning, by generating a new key and self-signed certificate.
+
+#### If you uploaded the wrong encryption certificate
 
 Your connection to GOV.UK Verify will break if you upload an encryption certificate that doesn’t match any of your private encryption keys. This is because your component won’t be able to use the private encryption keys to decrypt messages from the GOV.UK Verify Hub.
 
 To restore your connection to GOV.UK Verify, replace the wrong certificate by [uploading the encryption certificate][manage-certs] corresponding to your new encryption key.
 
-## If you uploaded the wrong signing certificate
-
+#### If you uploaded the wrong signing certificate
 
 If you uploaded a signing certificate that doesn’t match your new private signing key, you must remove that certificate from the GOV.UK Verify Manage certificates service and then upload the correct one.
 
 1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
 2. Select the signing certificate that doesn’t match your new private key.
 3. Select **Stop using this certificate**.
-4. Upload the correct cert using the [GOV.UK Verify Manage certificates service][manage-certs]
+4. Upload the correct cert using the [GOV.UK Verify Manage certificates service][manage-certs].
+
+
+### 4. Check that the uploaded certificate matches your new key
+
+If the uploaded certificate you checked in Step 3 is the right one, you should make sure it matches the new private key your component is using.
+
+For example, you can use `openssl` to check if the certificate you uploaded matches the new private key your component is using. A private key matches a certificate if their 'modulus' sections are identical. Create an MD5 hash for the modulus if you are comparing the output strings by eye.
+
+```sh
+openssl x509 -noout -modulus -in <certificate>.crt | openssl md5
+openssl rsa -noout -modulus -in <private-key>.key | openssl md5
+```
+
+If the private key and certificate don't match, you should replace the private key with the correct match. If the correct match is not available or has been compromised, start the rotation from the beginning, by generating a new key and self-signed certificate.
 
 <%= partial "partials/links" %>

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -16,11 +16,11 @@ If any of the private keys securing your connection to GOV.UK Verify have been c
 
 You must stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
 
-## If your connection breaks during a rotation
+## If your connection breaks during a key rotation
 
 These steps will help you find out:
 
-* what caused your connection to break during the rotation
+* what caused your connection to break during the key rotation
 * how to restore your connection
 
 ### 1. Restart your component
@@ -29,7 +29,7 @@ Make sure your component is using the new key, and certificate, if applicable. F
 
 ### 2. Apply configuration changes to all instances
 
-Make sure you restart all instances of the component you're doing the rotation for. This ensures all instances are using the new keys in their configuration.
+Make sure you restart all instances of the component you're doing the key rotation for. This ensures all instances are using the new keys in their configuration.
 
 ### 3. Check that the uploaded certificate is the right one
 
@@ -68,6 +68,7 @@ If you uploaded a signing certificate that doesn’t match your new private sign
 3. Select **Stop using this certificate**.
 4. Upload the correct certificate using the [GOV.UK Verify Manage certificates service][manage-certs].
 
+If you don't have the right certificate, [start a new key rotation process][rotating-keys-certs].
 
 ### 4. Check that the uploaded certificate matches your new key
 
@@ -80,6 +81,6 @@ openssl x509 -noout -modulus -in <certificate>.crt | openssl md5
 openssl rsa -noout -modulus -in <private-key>.key | openssl md5
 ```
 
-If the private key and certificate don't match, you should replace the private key with the correct match. If the correct match is not available or has been compromised, start the rotation from the beginning, by generating a new key and self-signed certificate.
+If the private key and certificate don't match, you should replace the private key with the correct match. If the correct match is not available or has been compromised, [start a new key rotation process][rotating-keys-certs].
 
 <%= partial "partials/links" %>

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -43,9 +43,9 @@ For example, you should check:
 * **Common name** for information about the intended use for the certificate
 * **Environment** to see which GOV.UK Verify environment uses your certificate
 
-If the uploaded certificate is the right certificate, go to [Step 4][troubleshooting-4] to continue troubleshooting your connection.
+#### If the uploaded certificate is the right one
 
-If the uploaded certificate is the wrong one, you can replace it with the right one. If you don't have the right certificate, start the rotation from the beginning, by generating a new key and self-signed certificate.
+If the information in the **Common name** matches the environment and component of the uploaded certificate, go to [Step 4][troubleshooting-4] to continue troubleshooting your connection.
 
 #### If you uploaded the wrong encryption certificate
 
@@ -57,7 +57,6 @@ To restore your connection to GOV.UK Verify, replace the wrong certificate with 
 2. Select the encryption certificate that doesn’t match your new private key.
 3. Select **Replace certificate** and follow the instructions.
 
-by [uploading the encryption certificate][manage-certs] corresponding to your new encryption key.
 
 #### If you uploaded the wrong signing certificate
 
@@ -68,7 +67,10 @@ If you uploaded a signing certificate that doesn’t match your new private sign
 3. Select **Stop using this certificate**.
 4. Upload the correct certificate using the [GOV.UK Verify Manage certificates service][manage-certs].
 
+#### If you don't have the right certificate
+
 If you don't have the right certificate, [start a new key rotation process][rotating-keys-certs].
+
 
 ### 4. Check that the uploaded certificate matches your new key
 

--- a/source/emergency-procedures/index.html.md.erb
+++ b/source/emergency-procedures/index.html.md.erb
@@ -5,84 +5,11 @@ weight: 65
 
 # Emergency procedures
 
-This page has guidance about what to do in situations that can break or compromise your service's connection to GOV.UK Verify.
+This section has guidance about what to do in situations when your connection to GOV.Uk Verify is broken or compromised.
 
-## If there is a private key leak
+Find out what to do in case of a:
 
-If any of the private keys securing your connection to GOV.UK Verify have been compromised, you are having a security incident. In addition to following your organisation's procedure, you must:
-
-* [replace the compromised keys][rotate-keys] immediately
-* [let the GOV.UK Verify team know][support] so they can help reduce the impact of the incident and run fraud and security checks
-
-You must stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
-
-## If your connection breaks during a key rotation
-
-These steps will help you find out:
-
-* what caused your connection to break during the key rotation
-* how to restore your connection
-
-### 1. Restart your component
-
-Make sure your component is using the new key, and certificate, if applicable. For example, you must restart the Verify Service Provider after a configuration change for it to start using the new key.
-
-### 2. Apply configuration changes to all instances
-
-Make sure you restart all instances of the component you're doing the key rotation for. This ensures all instances are using the new keys in their configuration.
-
-### 3. Check that the uploaded certificate is the right one
-
-1. Go to the [GOV.UK Verify Manage certificates service][manage-certs].
-2. Select the certificate you want to investigate.
-3. Use the certificate details to figure out if this is the certificate you intended to use.
-
-For example, you should check:
-
-* that the certificate was uploaded to the correct component
-* **Common name** for information about the intended use for the certificate
-* **Environment** to see which GOV.UK Verify environment uses your certificate
-
-#### If the uploaded certificate is the right one
-
-If the information in the **Common name** matches the environment and component of the uploaded certificate, go to [Step 4][troubleshooting-4] to continue troubleshooting your connection.
-
-#### If you uploaded the wrong encryption certificate
-
-Your connection to GOV.UK Verify will break if you upload an encryption certificate that doesn’t match any of your private encryption keys. This is because your component won’t be able to use the private encryption keys to decrypt messages from the GOV.UK Verify Hub.
-
-To restore your connection to GOV.UK Verify, replace the wrong certificate with the correct one.
-
-1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-2. Select the encryption certificate that doesn’t match your new private key.
-3. Select **Replace certificate** and follow the instructions.
-
-
-#### If you uploaded the wrong signing certificate
-
-If you uploaded a signing certificate that doesn’t match your new private signing key, you must remove that certificate from the GOV.UK Verify Manage certificates service and then upload the correct one.
-
-1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-2. Select the signing certificate that doesn’t match your new private key.
-3. Select **Stop using this certificate**.
-4. Upload the correct certificate using the [GOV.UK Verify Manage certificates service][manage-certs].
-
-#### If you don't have the right certificate
-
-If you don't have the right certificate, [start a new key rotation process][rotating-keys-certs].
-
-
-### 4. Check that the uploaded certificate matches your new key
-
-If the uploaded certificate you checked in Step 3 is the right one, you should make sure it matches the new private key your component is using.
-
-For example, you can use `openssl` to check if the certificate you uploaded matches the new private key your component is using. A private key matches a certificate if their 'modulus' sections are identical. Create an MD5 hash for the modulus if you are comparing the output strings by eye.
-
-```sh
-openssl x509 -noout -modulus -in <certificate>.crt | openssl md5
-openssl rsa -noout -modulus -in <private-key>.key | openssl md5
-```
-
-If the private key and certificate don't match, you should replace the private key with the correct match. If the correct match is not available or has been compromised, [start a new key rotation process][rotating-keys-certs].
+* [private key leak][private-key-leak]
+* [broken connection during key rotation][broken-connection-rotation]
 
 <%= partial "partials/links" %>

--- a/source/emergency-procedures/private-key-leak/index.html.md.erb
+++ b/source/emergency-procedures/private-key-leak/index.html.md.erb
@@ -1,0 +1,15 @@
+---
+title: Private key leak
+weight: 10
+---
+
+# Private key leak
+
+If any of the private keys securing your connection to GOV.UK Verify have been compromised, you are having a security incident. In addition to following your organisation's procedure, you must:
+
+* [replace the compromised keys][rotate-keys] immediately
+* [let the GOV.UK Verify team know][support] so they can help reduce the impact of the incident and run fraud and security checks
+
+You must stop using the compromised keys as soon as possible. The quickest way to do this is by rotating your keys and certificates using the [GOV.UK Verify Manage certificates service][manage-certs].
+
+<%= partial "partials/links" %>

--- a/source/partials/_get-self-signed-certificates.erb
+++ b/source/partials/_get-self-signed-certificates.erb
@@ -1,4 +1,4 @@
-Use your preferred method to generate a new private key and self-signed certificate pair. 
+Use your preferred method to generate a new private key and self-signed certificate pair.
 
 Make sure the private key is [PKCS #8](https://tools.ietf.org/html/rfc5208) formatted with a `.pk8` extension.
 
@@ -24,19 +24,22 @@ Generate your private key and self-signed certificate:
 openssl req -x509 -newkey rsa:2048 -days 365 -nodes -sha256 \
    -keyout <private-key>.pk8 -out <certificate>.crt
 ```
-     
+
 The terminal will prompt you for information. You must provide a `Common Name`. All other information is optional.
 
-The `Common Name` is the part of the certificate metadata that helps you identify that certificate more easily. You will see the value you entered for `Common Name` in the user interface for the GOV.UK Verify Manage certificates service when you check if you uploaded the right certificate.
+The `Common Name` is the part of the certificate metadata that helps you identify that certificate more easily. You can use the `Common Name` to check you've uploaded the right certificate when using the GOV.UK Verify Manage certificates service.
 
-`Common Name` must not contain underscores.
-     
-There is no mandatory naming convention for `Common Name`, but you may find it useful to include the:
-     
+There is no mandatory naming convention for `Common Name`, but it's useful during troubleshooting if you include the:
+
 * name of your service
 * name of the component the certificate is for
 * environment name you generated the certificate for
-* certificate type, for example signing or encryption
+* certificate type
 * version number for your certificate
+
+`Common Name` must not contain underscores.
+
+For example, the common name could be `Universal-Credit-MSA-integration-signing-01`.
+
   </div>
 </details>

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -12,6 +12,7 @@
 
 [manage-certs]: https://connecting-to-verify-prototype.herokuapp.com/self-serve/sign-in
 [openssl-github]: https://github.com/openssl/openssl
+[troubleshooting-4]: /emergency-procedures/#if-you-uploaded-the-wrong-signing-certificate
 
 [vsp-readme]: https://github.com/alphagov/verify-service-provider/blob/master/README.md
 [vsp-readme-setup]: https://github.com/alphagov/verify-service-provider/blob/master/README.md#setup

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -59,6 +59,7 @@
 [vsp-encryption]: /maintain-your-connection/update-vsp-encryption
 [vsp-signing]: /maintain-your-connection/update-vsp-signing
 [vsp-keys]: /maintain-your-connection/vsp
+[rotating-keys-certs]: /rotating-your-keys-and-certificates
 
 [get-cert-prod]: /connect-to-production/get-certificates
 [get-cert-test]: /test-in-integration/get-certificates

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -12,7 +12,8 @@
 
 [manage-certs]: https://connecting-to-verify-prototype.herokuapp.com/self-serve/sign-in
 [openssl-github]: https://github.com/openssl/openssl
-[troubleshooting-4]: /emergency-procedures/#if-you-uploaded-the-wrong-signing-certificate
+[troubleshooting-4]: /emergency-procedures/broken-connection-during-rotation/#step-4-check-the-uploaded-certificate-matches-your-new-key
+[troubleshooting-3]: /emergency-procedures/broken-connection-during-rotation/#step-3-check-the-uploaded-certificate
 
 [vsp-readme]: https://github.com/alphagov/verify-service-provider/blob/master/README.md
 [vsp-readme-setup]: https://github.com/alphagov/verify-service-provider/blob/master/README.md#setup

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -61,6 +61,9 @@
 [vsp-keys]: /maintain-your-connection/vsp
 [rotating-keys-certs]: /rotating-your-keys-and-certificates
 
+[private-key-leak]: /emergency-procedures/private-key-leak
+[broken-connection-rotation]: /emergency-procedures/broken-connection-during-rotation
+
 [get-cert-prod]: /connect-to-production/get-certificates
 [get-cert-test]: /test-in-integration/get-certificates
 [get-env-access-test]: /test-in-integration/request-access


### PR DESCRIPTION
## Background

We need a "Troubleshooting" section aimed at a broken connection during key rotation. Existing content tells users what to do if they uploaded the wrong cert, but in reality, they're not likely to know they did this. They'll only realise something went wrong when the connection breaks and they often won't know why. The Troubleshooting section is meant to helps users work their way through things that might have gone wrong.

## Proposed changes

"Troubleshooting a broken connection" section on the "Emergency procedures" page.

The steps were formulated based on the most common scenarios encountered by Verify Support.

The content includes the existing content about what to do when uploading the wrong certificate.

## How to review

**Technical and product review:** check the flow makes sense and the content is easy to understand.

**Content review:** check for readability and style.