### PR TITLE
Template cert rotation

### DIFF
--- a/source/partials/_add-new-key.erb
+++ b/source/partials/_add-new-key.erb
@@ -1,6 +1,6 @@
 
 <% if component == "VSP" %>
-Add your new <%= component %> private encryption key to the `samlSecondaryEncryptionKey` field in the <%= component %> configuration file.
+Add your new <%= component %> private encryption key to `samlSecondaryEncryptionKey` in the <%= component %> configuration file.
 
 Restart the <%= component %> to implement the configuration changes. The <%= component %> can now use both the new and old keys to decrypt SAML messages.
 <% end %>

--- a/source/partials/_add-new-key.erb
+++ b/source/partials/_add-new-key.erb
@@ -1,0 +1,73 @@
+
+<% if component == "VSP" %>
+Add your new <%= component %> private encryption key to the `samlSecondaryEncryptionKey` field in the <%= component %> configuration file.
+
+Restart the <%= component %> to implement the configuration changes. The <%= component %> can now use both the new and old keys to decrypt SAML messages.
+<% end %>
+
+<% if component == "MSA" and type == "encryption" %>
+
+Add a second list item containing the details for your new key and self-signed certificate under `encryptionKeys` in your [MSA configuration][msa-config], for example:
+
+```yaml
+encryptionKeys:
+- publicKey:
+    certFile: msa_encryption_2016.crt
+    name: MSA Encryption 2016
+  privateKey:
+    keyFile: msa_encryption_2016.pk8
+- publicKey:
+    certFile: msa_encryption_2017.crt
+    name: MSA Encryption 2017
+  privateKey:
+    keyFile: msa_encryption_2017.pk8
+```
+
+| Field name | Description                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| `certFile` | The name of the `.crt` file containing your certificate                                                |
+| `name`     | A meaningful name for your certificate which is published in your MSA's metadata |
+| `keyFile`  |  The name of the `.pk8` file containing your private key                                                                                                |
+
+Restart the MSA to implement the configuration changes. The MSA can now use both the new and old keys to decrypt SAML messages.
+
+<% end %>
+
+
+<% if component == "MSA" and type == "signing" %>
+
+Add your new signing key and self-signed certificate to `signingKeys.secondary` in your MSA configuration, for example:
+
+```yaml
+signingKeys:
+  primary:
+    publicKey:
+      certFile: msa_signing_2016.crt
+      name: 2016 MSA Signing Key
+    privateKey:
+      keyFile: msa_signing_2016.pk8
+  secondary:
+    publicKey:
+      certFile: msa_signing_2017.crt
+      name: 2017 MSA Signing Key
+    privateKey:
+      keyFile: msa_signing_2017.pk8
+```
+
+| Field name | Description                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| `certFile` | The name of the `.crt` file containing your certificate                                                |
+| `name`     | A meaningful name for your certificate which is published in your MSA's metadata |
+| `keyFile`  |  The name of the `.pk8` file containing your private key                                                                                                |
+
+
+Restart the MSA to publish the new signing certificate to its metadata. You must do this because the MSA publishes its certificates containing the public keys in its own metadata at run time. The service provider you’re using reads this metadata and uses the MSA's signing certificate to trust assertions signed by the MSA.
+
+If you’re using the VSP, wait for it to load the MSA metadata. The VSP periodically refreshes its metadata and will log when it has finished. Once it loads the new metadata, the VSP trusts assertions signed with the new MSA signing key.
+
+<% end %>
+
+
+<% if component == "service provider" %>
+Add your new service provider private encryption key to your service provider. Your service can now use both the new and old keys to decrypt SAML messages.
+<% end %>

--- a/source/partials/_remove-old-certificate.erb
+++ b/source/partials/_remove-old-certificate.erb
@@ -1,0 +1,7 @@
+To make sure the GOV.UK Verify Hub doesn't trust messages signed with your old  key, you must also remove your old certificate from the GOV.UK Verify Hub configuration.
+
+1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+1. Select the <%= component %> <%= type %> certificate due to expire.
+1. Select **Stop using this certificate**.
+
+The GOV.UK Verify Hub now only trusts messages signed with your new <%= component %> <%= type %> key.

--- a/source/partials/_remove-old-key.erb
+++ b/source/partials/_remove-old-key.erb
@@ -1,0 +1,51 @@
+<% if type == "encryption" %>
+
+The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub is now using your new certificate to encrypt messages for your service. This means you can remove the old encryption key from your <%= component %> configuration.
+
+<newline>
+
+<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before removing the old encryption key.') %>
+
+<% if component == "VSP" %>
+
+To remove the old encryption key from the <%= component %> configuration:
+
+1. Remove the key in `samlPrimaryEncryptionKey` and replace it with the key from `samlSecondaryEncryptionKey`.
+1. Leave `samlSecondaryEncryptionKey` empty for the next update.
+1. Restart the <%= component %> to implement the configuration changes.
+
+<% end %>
+
+
+<% if component == "MSA" %>
+
+Delete the old encryption key and certificate from your <%= component %>'s configuration.
+
+Remember to restart the <%= component %> to implement the configuration changes.
+
+While both old and new keys are in use, you may see error messages in the logs with the description `Unwrapping failed`. These messages appear because the MSA attempts to decrypt the SAML message using each key in turn. You can safely ignore these messages. However, do not ignore any other error messages related to SAML decryption.
+
+<% end %>
+
+Once you've removed the old <%= type %> key, your <%= component %> only uses the new encryption key to decrypt messages from GOV.UK Verify Hub.
+
+<% end %>
+
+
+<% if component == "MSA" and type == "signing" %>
+
+The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub now trusts messages signed with your new VSP signing key. This means you can replace the old signing key from your VSP configuration.
+
+<newline>
+
+<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before deleting the old signing key.') %>
+
+To remove the old encryption key from the VSP configuration:
+
+1. Delete the `signingKeys.primary` section.
+1. Rename `signingKeys.secondary` to `signingKeys.primary`. The MSA now signs the assertions with the new  key.
+1. Restart the MSA to update its metadata to contain only the new signing certificate.
+
+Your service provider now trusts assertions signed with your new <%= component %> signing key.
+
+<% end %>

--- a/source/partials/_replace-old-key.erb
+++ b/source/partials/_replace-old-key.erb
@@ -1,0 +1,26 @@
+
+The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub now trusts messages signed with your new <%= component %> <%= type %> key. This means you can replace the old <%= type %> key from your <%= component %> configuration.
+
+<newline>
+
+<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before replacing the old key.') %>
+
+
+<% if component == "VSP" %>
+
+To replace the old encryption key from the <%= component %> configuration:
+
+1. Replace the old <%= type %> key under `samlSigningKey` in the <%= component %> configuration with the new key.
+1. Restart the <%= component %> to implement the configuration changes.
+
+Your <%= component %> now signs messages for the GOV.UK Verify Hub using your new <%= type %> key.
+
+<% end %>
+
+
+
+<% if component == "service provider" %>
+
+Replacing your old private <%= type %> key with the new key means your service now signs messages for the GOV.UK Verify Hub using your new key.
+
+<% end %>

--- a/source/partials/_restore-connection.erb
+++ b/source/partials/_restore-connection.erb
@@ -1,0 +1,5 @@
+Replace your old service provider private encryption key with the new one.
+
+Your connection to GOV.UK Verify is restored once your new service provider encryption key is live.
+
+Once your new encryption key is live, your service provider will be using it to decrypt messages from GOV.UK Verify Hub.

--- a/source/partials/_upload-new-certificate.erb
+++ b/source/partials/_upload-new-certificate.erb
@@ -1,0 +1,30 @@
+Upload your new <%= type %> certificate to the GOV.UK Verify Manage certificates service.
+
+<% if type == "signing" %>
+
+This starts a deployment process that adds your new <%= component %> <%= type %> certificate to the GOV.UK Verify Hub configuration.
+When the deployment is complete, the GOV.UK Verify Hub will be using both your new and your old certificate to check the signature on messages coming from your service.
+
+<% end %>
+
+<% if type == "encryption" %>
+
+This starts a deployment process to replace your old <%= component %> encryption certificate with the new one in the GOV.UK Verify Hub configuration. When the deployment is complete, the GOV.UK Verify Hub will be using your new certificate to encrypt messages for your service.
+
+<% end %>
+
+<% if component == "service provider" and dual_running == "no" %>
+
+<newline>
+
+<%= warning_text('Your connection to GOV.UK Verify will break once your new encryption certificate is deployed to the GOV.UK Verify Hub. Restore your connection in the next step.') %>
+
+<% end %>
+
+The deployment process takes approximately 10 minutes. You will receive an e-mail confirmation when the GOV.UK Verify Hub starts using your new <%= type %> certificate. You can also check the deployment status on the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+
+<% if dual_running == "yes" %>
+
+Wait for deployment confirmation before moving to the next step.
+
+<% end %>

--- a/source/rotating-your-keys-and-certificates/msa-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/msa-encryption/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Matching Service Adapter encryption
-weight: 10
+weight: 40
 ---
 
 <%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>

--- a/source/rotating-your-keys-and-certificates/msa-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/msa-encryption/index.html.md.erb
@@ -1,65 +1,37 @@
 ---
 title: Matching Service Adapter encryption
-weight: 25
+weight: 10
 ---
+
+<%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
+<% locals = { component: "MSA", type: "encryption", action: "encrypt", dual_running: "yes" } %>
+<%# The markdown content for this page starts below. %>
 
 # Matching Service Adapter encryption
 
 If your connection to GOV.UK Verify involves a Matching Service Adapter (MSA), you are responsible for keeping its encryption and signing certificates up to date.
 
-You must update the certificates containing your MSA's public keys before they expire. If you don't, your users wont be able to access your service using GOV.UK Verify.
+You must update the certificates containing your MSA's public keys before they expire. If you don't, your users will not be able to access your service using GOV.UK Verify.
 
 ## Rotate your MSA encryption key and certificate
 
 ### Step 1. Create a new self-signed encryption certificate
 
-<%= partial("partials/get-self-signed-certificates") %>
+  <%= partial "partials/get-self-signed-certificates" %>
 
 ### Step 2. Add the new encryption key and certificate to your MSA configuration
 
-Add a second list item containing the details for your new key and self-signed certificate under `encryptionKeys` in your [MSA configuration][msa-config], for example:
-
-```yaml
-encryptionKeys:
-- publicKey:
-    certFile: msa_encryption_2016.crt
-    name: MSA Encryption 2016
-  privateKey:
-    keyFile: msa_encryption_2016.pk8
-- publicKey:
-    certFile: msa_encryption_2017.crt
-    name: MSA Encryption 2017
-  privateKey:
-    keyFile: msa_encryption_2017.pk8
-```
-
-| Field name | Description                                                                                       |
-| ---------- | ------------------------------------------------------------------------------------------------- |
-| `certFile` | The name of the `.crt` file containing your certificate                                                |
-| `name`     | A meaningful name for your certificate which is published in your MSA's metadata |
-| `keyFile`  |  The name of the `.pk8` file containing your private key                                                                                                |
-
-Restart the MSA to implement the configuration changes. The MSA can now use both the new and old keys to decrypt SAML messages.
+  <%= partial "partials/add-new-key", locals: locals %>
 
 ### Step 3. Upload the new encryption certificate
 
-Upload your new encryption certificate to the GOV.UK Verify Manage certificates service.
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
-This starts a deployment process to replace your old MSA encryption certificate with the new one in the GOV.UK Verify Hub configuration.
-When the deployment is complete, the GOV.UK Verify Hub will be using your new certificate to encrypt messages for your service.
+### Step 4. Delete the old MSA encryption key and certificate
 
-The deployment process takes approximately 10 minutes. You will receive e-mail confirmation when the GOV.UK Verify Hub starts using your new encryption certificate. You can also check the deployment status on the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+  <%= partial "partials/remove-old-key", locals: locals %>
 
-Wait for deployment confirmation before moving to the next step.
 
-### Step 4. Delete the old encryption key and certificate
-
-Delete the old encryption key and certificate.
-
-Restart the MSA to implement the configuration changes.
-
-The MSA now uses the new encryption key to decrypt SAML messages, and the GOV.UK Verify hub now uses your new self-signed encryption certificate to encrypt SAML messages for your service.
-
-> While both old and new keys are in use, you may see error messages in the logs with the description `Unwrapping failed`. These messages appear because the MSA attempts to decrypt the SAML message using each key in turn. You can safely ignore these messages. However, do not ignore any other error messages related to SAML decryption.
+<%#= Add in the link label definitions %>
 
 <%= partial "partials/links" %>

--- a/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
@@ -3,85 +3,37 @@ title: Matching Service Adapter signing
 weight: 20
 ---
 
+<%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
+<% locals = { component: "MSA", type: "signing", action: "sign", dual_running: "yes" } %>
+<%# The markdown content for this page starts below. %>
+
 # Matching Service Adapter signing
 
 If your connection to GOV.UK Verify involves a Matching Service Adapter (MSA), you are responsible for keeping its encryption and signing certificates up to date.
 
-You must update the certificates containing your MSA's public keys before they expire. If you don't, your users wont be able to access your service using GOV.UK Verify.
-
+You must update the certificates containing your MSA's public keys before they expire. If you don't, your users will not be able to access your service using GOV.UK Verify.
 
 ## Rotate your MSA signing key and certificate
 
 ### Step 1. Create a new self-signed signing certificate
 
-<%= partial("partials/get-self-signed-certificates") %>
+  <%= partial "partials/get-self-signed-certificates" %>
 
 ### Step 2. Upload the new signing certificate
 
-Upload your new signing certificate to the GOV.UK Verify Manage certificates service.
-
-This starts a deployment process that adds your new MSA signing certificate to the GOV.UK Verify Hub configuration.
-When the deployment is complete, the GOV.UK Verify Hub will be using both your new and your old certificate to check the signature on messages coming from your service.
-
-The deployment process takes approximately 10 minutes. You will receive e-mail confirmation when the GOV.UK Verify Hub starts using your new encryption certificate. You can also check the deployment status on the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-
-In the meantime, you can move on to the next step, adding the new signing key and certificate to your MSA configuration.
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
 ### Step 3. Add the new signing key and certificate to your MSA configuration
 
-Add your new signing key and self-signed certificate to `signingKeys.secondary` in your MSA configuration, for example:
+  <%= partial "partials/add-new-key", locals: locals %>
 
-```yaml
-signingKeys:
-  primary:
-    publicKey:
-      certFile: msa_signing_2016.crt
-      name: 2016 MSA Signing Key
-    privateKey:
-      keyFile: msa_signing_2016.pk8
-  secondary:
-    publicKey:
-      certFile: msa_signing_2017.crt
-      name: 2017 MSA Signing Key
-    privateKey:
-      keyFile: msa_signing_2017.pk8
-```
+### Step 4. Delete the old MSA signing key and certificate
 
-| Field name | Description                                                                                       |
-| ---------- | ------------------------------------------------------------------------------------------------- |
-| `certFile` | The name of the `.crt` file containing your certificate                                                |
-| `name`     | A meaningful name for your certificate which is published in your MSA's metadata |
-| `keyFile`  |  The name of the `.pk8` file containing your private key                                                                                                |
-
-
-Restart the MSA to publish the new signing certificate to its metadata. You must do this because the MSA publishes its certificates containing the public keys in its own metadata at run time. The service provider you’re using reads this metadata and uses the MSA's signing certificate to trust assertions signed by the MSA.
-
-If you’re using the VSP, wait for it to load the MSA metadata. The VSP periodically refreshes its metadata and will log when it has finished. Once it loads the new metadata, the VSP trusts assertions signed with the new MSA signing key.
-
-### Step 4. Delete the old signing key and certificate
-
-The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub now trusts messages signed with your new VSP signing key. This means you can replace the old signing key from your VSP configuration.
-
-<newline>
-
-<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before deleting the old signing key.') %>
-
-To remove the old encryption key from the VSP configuration:
-
-1. Delete the `signingKeys.primary` section.
-1. Rename `signingKeys.secondary` to `signingKeys.primary`. The MSA now signs the assertions with the new  key.
-1. Restart the MSA to update its metadata to contain only the new signing certificate.
-
-Your service provider now trusts assertions signed with your new MSA signing key.
+  <%= partial "partials/remove-old-key", locals: locals %>
 
 ### Step 5. Remove your old certificate from the GOV.UK Verify Hub configuration
 
-To make sure the GOV.UK Verify Hub doesn't trust messages signed with your old  key, you must also remove your old certificate from the GOV.UK Verify Hub configuration.
+  <%= partial "partials/remove-old-certificate", locals: locals %>
 
-1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-1. Select the VSP certificate due to expire.
-1. Select **Stop using this certificate**.
-
-The GOV.UK Verify Hub now only trusts messages signed with your new service provider signing key.
-
+<%#= Add in the link label definitions - this is makes the URLs on this page work. %>
 <%= partial "partials/links" %>

--- a/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Matching Service Adapter signing
-weight: 20
+weight: 30
 ---
 
 <%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>

--- a/source/rotating-your-keys-and-certificates/service-provider-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-encryption/index.html.md.erb
@@ -3,6 +3,10 @@ title: Service provider encryption
 weight: 30
 ---
 
+<%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
+<% locals = { component: "service provider", type: "encryption", action: "encrypt", dual_running: "yes" } %>
+<%# The markdown content for this page starts below. %>
+
 # Service provider encryption
 
 If you built your own service provider to connect to GOV.UK Verify, you are responsible for keeping its encryption and signing certificates up to date.
@@ -15,27 +19,21 @@ If you're using the Verify Service Provider, [see how to update your Verify Serv
 
 ### Step 1. Create a new self-signed encryption certificate
 
-<%= partial("partials/get-self-signed-certificates") %>
+  <%= partial "partials/get-self-signed-certificates" %>
 
 ### Step 2. Add the new encryption key and certificate
 
-Add your new service provider private encryption key to your service provider. Your service can now use both the new and old keys to decrypt SAML messages.
+  <%= partial "partials/add-new-key", locals: locals %>
 
 ### Step 3. Upload the new encryption certificate
 
-Upload your new encryption certificate to the GOV.UK Verify Manage certificates service.
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
-This starts a deployment process to replace your old service provider encryption certificate with the new one in the GOV.UK Verify Hub configuration.
-When the deployment is complete, the GOV.UK Verify Hub will be using your new certificate to encrypt messages for your service.
+### Step 4. Delete the old encryption key
 
-The deployment process takes approximately 10 minutes. You will receive e-mail confirmation when the GOV.UK Verify Hub starts using your new encryption certificate. You can also check the deployment status on the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+  <%= partial "partials/remove-old-key", locals: locals %>
 
-Wait for deployment confirmation before moving to the next step.
 
-### Step 4. Delete the old encryption key and certificate
-
-Remove your old encryption key from your service provider configuration.
-
-Your service provider now uses the new encryption key to decrypt SAML messages.
+<%# Add in the link label definitions %>
 
 <%= partial "partials/links" %>

--- a/source/rotating-your-keys-and-certificates/service-provider-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-encryption/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Service provider encryption
-weight: 30
+weight: 60
 ---
 
 <%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>

--- a/source/rotating-your-keys-and-certificates/service-provider-encryption/service-provider-encryption-no-dual-run/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-encryption/service-provider-encryption-no-dual-run/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Service provider without dual running
-weight: 30
+weight: 70
 ---
 
 <%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>

--- a/source/rotating-your-keys-and-certificates/service-provider-encryption/service-provider-encryption-no-dual-run/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-encryption/service-provider-encryption-no-dual-run/index.html.md.erb
@@ -3,6 +3,10 @@ title: Service provider without dual running
 weight: 30
 ---
 
+<%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
+<% locals = { component: "service provider", type: "encryption", action: "encrypt", dual_running: "no" } %>
+<%# The markdown content for this page starts below. %>
+
 # Service provider without dual running
 
 If you built your own service provider to connect to GOV.UK Verify, you are responsible for keeping its encryption and signing certificates up to date.
@@ -11,31 +15,21 @@ Because your service provider does not support dual running for your encryption 
 
 If you're using the Verify Service Provider, [see how to update your Verify Service Provider keys][vsp-keys].
 
-## Replace your service provider encryption key and certificate
+## Rotate your service provider encryption key and certificate
 
 ### Step 1. Create a new self-signed encryption certificate
 
-<%= partial("partials/get-self-signed-certificates") %>
+  <%= partial "partials/get-self-signed-certificates" %>
 
 ### Step 2. Upload the new encryption certificate
 
-Upload your new encryption certificate to the GOV.UK Verify Manage certificates service.
-
-This starts a deployment process to replace your old service provider encryption certificate with the new one in the GOV.UK Verify Hub configuration.
-When the deployment is complete, the GOV.UK Verify Hub will be using your new certificate to encrypt messages for your service.
-
-<newline>
-
-<%= warning_text('Your connection to GOV.UK Verify will break once your new encryption certificate is deployed to the GOV.UK Verify Hub. Restore your connection in the next step.') %>
-
-The deployment process takes approximately 10 minutes. You will receive e-mail confirmation when the GOV.UK Verify Hub starts using your new encryption certificate. You can also check the deployment status on the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
 ### Step 3. Replace the old encryption key
 
-Replace your old service provider private encryption key with the new one.
+  <%= partial "partials/restore-connection", locals: locals %>
 
-Your connection to GOV.UK Verify is restored once your new service provider encryption key is live.
 
-Once your new encryption key is live, your service provider will be using it to decrypt messages from GOV.UK Verify Hub.
+<%# Add in the link label definitions %>
 
 <%= partial "partials/links" %>

--- a/source/rotating-your-keys-and-certificates/service-provider-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-signing/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Service provider signing
-weight: 30
+weight: 50
 ---
 
 <%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>

--- a/source/rotating-your-keys-and-certificates/service-provider-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-signing/index.html.md.erb
@@ -3,6 +3,10 @@ title: Service provider signing
 weight: 30
 ---
 
+<%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
+<% locals = { component: "service provider", type: "signing", action: "sign", dual_running: "yes" } %>
+<%# The markdown content for this page starts below. %>
+
 # Service provider signing
 
 If you built your own service provider to connect to GOV.UK Verify, you are responsible for keeping its encryption and signing certificates up to date.
@@ -13,38 +17,21 @@ If you're using the Verify Service Provider, [see how to update your Verify Serv
 
 ### Step 1. Create a new self-signed signing certificate
 
-<%= partial("partials/get-self-signed-certificates") %>
+  <%= partial "partials/get-self-signed-certificates" %>
 
 ### Step 2. Upload the new signing certificate
 
-Upload your new signing certificate to the GOV.UK Verify Manage certificates service.
-
-This starts a deployment process that adds your new service provider signing certificate to the GOV.UK Verify Hub configuration.
-When the deployment is complete, the GOV.UK Verify Hub will be using both your new and your old certificate to check the signature on messages coming from your service.
-
-The deployment process takes approximately 10 minutes. You will receive e-mail confirmation when the GOV.UK Verify Hub starts using your new encryption certificate. You can also check the deployment status on the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-
-Wait for this confirmation before moving to the next step.
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
 ### Step 3. Replace the old signing key
 
-The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub now trusts messages signed with your new VSP signing key. This means you can replace the old signing key from your VSP configuration.
-
-<newline>
-
-<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before replacing the old signing key.') %>
-
-Replacing your old private signing key with the new key means your service now signs messages for the GOV.UK Verify Hub using your new key.
+  <%= partial "partials/replace-old-key", locals: locals %>
 
 ### Step 4. Remove your old certificate from the GOV.UK Verify Hub configuration
 
-To make sure the GOV.UK Verify Hub doesn't trust messages signed with your old  key, you must also remove your old certificate from the GOV.UK Verify Hub configuration.
+  <%= partial "partials/remove-old-certificate", locals: locals %>
 
-1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-1. Select the service provider signing certificate due to expire.
-1. Select **Stop using this certificate**.
 
-The GOV.UK Verify Hub now only trusts messages signed with your new service provider signing key.
-
+<%# Add in the link label definitions %>
 
 <%= partial "partials/links" %>

--- a/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Verify Service Provider encryption
-weight: 10
+weight: 20
 ---
 
 <%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>

--- a/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
@@ -15,7 +15,7 @@ If you're using a custom service provider, [go to the section about updating ser
 
 ## Rotate your VSP encryption key and certificate
 
-### Step 1 - Create a new self-signed encryption certificate
+### Step 1. Create a new self-signed encryption certificate
 
   <%= partial "partials/get-self-signed-certificates" %>
 

--- a/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
@@ -3,6 +3,10 @@ title: Verify Service Provider encryption
 weight: 10
 ---
 
+<%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
+<% locals = { component: "VSP", type: "encryption", action: "encrypt", dual_running: "yes" } %>
+<%# The markdown content for this page starts below. %>
+
 # Verify Service Provider encryption
 
 If you're using the Verify Service Provider (VSP) to connect to GOV.UK Verify, you are responsible for keeping its encryption and signing certificates up to date.
@@ -11,36 +15,23 @@ If you're using a custom service provider, [go to the section about updating ser
 
 ## Rotate your VSP encryption key and certificate
 
-### Step 1. Create a new self-signed encryption certificate
+### Step 1 - Create a new self-signed encryption certificate
 
-<%= partial("partials/get-self-signed-certificates") %>
+  <%= partial "partials/get-self-signed-certificates" %>
 
 ### Step 2. Add the new encryption key to the VSP configuration
 
-Add your new VSP private encryption key to `samlSecondaryEncryptionKey` in the VSP configuration file. 
+  <%= partial "partials/add-new-key", locals: locals %>
 
-Restart the VSP to implement the configuration changes. The VSP can now use both the new and old keys to decrypt SAML messages.
+### Step 3: Upload the new encryption certificate
 
-### Step 3. Upload the new encryption certificate
-
-To make GOV.UK Verify Hub use your new encryption self-signed certificate, upload it to the GOV.UK Verify Manage certificates service.
-
-You will receive e-mail confirmation that the GOV.UK Verify team have deployed your encryption certificate. Wait for this confirmation before moving to the next step.
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
 ### Step 4. Remove the old encryption key
 
-The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub is now using your new certificate to encrypt messages for your service. This means you can remove the old encryption key from your VSP configuration.
+  <%= partial "partials/remove-old-key", locals: locals %>
 
-<newline>
 
-<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before removing the old encryption key.') %>
-
-To remove the old encryption key from the VSP configuration:
-
-1. Remove the key in `samlPrimaryEncryptionKey` and replace it with the key from `samlSecondaryEncryptionKey`.
-1. Leave `samlSecondaryEncryptionKey` empty for the next rotation.
-1. Restart the VSP to implement the configuration changes.
-
-Your VSP now uses the new encryption key to decrypt SAML messages from GOV.UK Verify Hub.
+<%#= Add in the link label definitions %>
 
 <%= partial "partials/links" %>

--- a/source/rotating-your-keys-and-certificates/vsp-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/vsp-signing/index.html.md.erb
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 <%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
-<% locals = { component: "VSP", type: "signing", action: "sign", dual_running: "no" } %>
+<% locals = { component: "VSP", type: "signing", action: "sign", dual_running: "yes" } %>
 <%# The markdown content for this page starts below. %>
 
 # Verify Service Provider signing

--- a/source/rotating-your-keys-and-certificates/vsp-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/vsp-signing/index.html.md.erb
@@ -3,6 +3,10 @@ title: Verify Service Provider signing
 weight: 10
 ---
 
+<%# Define the local variables - these will be used to customise the content in the partial files called in this file. %>
+<% locals = { component: "VSP", type: "signing", action: "sign", dual_running: "no" } %>
+<%# The markdown content for this page starts below. %>
+
 # Verify Service Provider signing
 
 If you're using the Verify Service Provider (VSP) to connect to GOV.UK Verify, you are responsible for keeping its encryption and signing certificates up to date.
@@ -11,44 +15,23 @@ If you're using a custom service provider, [go to the section about updating ser
 
 ## Rotate your VSP signing key and certificate
 
-### Step 1. Create a new self-signed signing certificate
+### 1. Create a new self-signed signing certificate
 
-<%= partial("partials/get-self-signed-certificates") %>
+  <%= partial "partials/get-self-signed-certificates" %>
 
-### Step 2. Upload the new signing certificate
+### 2. Upload the new signing certificate
 
-Upload your new signing certificate to the GOV.UK Verify Manage certificates service.
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
-This starts a deployment process that adds your new VSP signing certificate to the GOV.UK Verify Hub configuration.
-When the deployment is complete, the GOV.UK Verify Hub will be using both your new and your old certificate to check the signature on messages coming from your service.
+### 3. Replace the old signing key
 
-The deployment process takes approximately 10 minutes. You will receive e-mail confirmation when the GOV.UK Verify Hub starts using your new encryption certificate. You can also check the deployment status on the [GOV.UK Verify Manage certificates service dashboard][dashboard].
+  <%= partial "partials/replace-old-key", locals: locals %>
 
-Wait for this confirmation before moving to the next step.
+### 4. Remove your old certificate from the GOV.UK Verify Hub configuration
 
-### Step 3. Replace the old signing key
+  <%= partial "partials/remove-old-certificate", locals: locals %>
 
-The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub now trusts messages signed with your new VSP signing key. This means you can replace the old signing key from your VSP configuration.
 
-<newline>
-
-<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before replacing the old signing key.') %>
-
-To replace the old encryption key from the VSP configuration:
-
-1. Replace the old signing key under `samlSigningKey` in the VSP configuration with the new key.
-1. Restart the VSP to implement the configuration changes.
-
-Your VSP now signs messages for the GOV.UK Verify Hub using your new signing key.
-
-### Step 4. Remove your old certificate from the GOV.UK Verify Hub configuration
-
-To make sure the GOV.UK Verify Hub doesn't trust messages signed with your old  key, you must also remove your old certificate from the GOV.UK Verify Hub configuration.
-
-1. Go to the [GOV.UK Verify Manage certificates service dashboard][dashboard].
-1. Select the VSP signing certificate due to expire.
-1. Select **Stop using this certificate**.
-
-The GOV.UK Verify Hub now only trusts messages signed with your new VSP signing key.
+<%#= Add in the link label definitions %>
 
 <%= partial "partials/links" %>


### PR DESCRIPTION
## Background

The key rotation docs are made up of 7 nearly identical steps. This makes it ~hard~ excruciatingly difficult to keep track of changes, update, and review content.

## Proposed changes

* Identify repeating steps across the 7 pages of docs.
* [Factor out these common steps into partials.](https://github.com/alphagov/verify-tech-docs/commit/5786b804384633daa7a803121a4fa6c133abb702)
* Use local variables as placeholders for component name, type of key/cert, and whether or not the rotation process applies to components that can dual run.
* [Re-build the 7 pages of docs using the partials.](https://github.com/alphagov/verify-tech-docs/commit/9eb90cdd078eb7c69a6f90d21e71d827d2f7e3e9)

## How to review

**Tech review:** Have I done any unforgivable filthy things in Ruby?
**Content review:** Make sure the output docs match the docs on the prototype-docs branch. See links in the Trello card.