### PR TITLE
Add additional openssl command to convert the key for MSA

### DIFF
--- a/source/partials/_get-self-signed-certificates.erb
+++ b/source/partials/_get-self-signed-certificates.erb
@@ -1,11 +1,15 @@
 Use your preferred method to generate a new private key and self-signed certificate pair.
 
-Make sure the private key is [PKCS #8](https://tools.ietf.org/html/rfc5208) formatted.
+<% if component == "MSA" %>
+  Make sure the private key is [PKCS #8](https://tools.ietf.org/html/rfc5208) formatted and DER encoded.
+<% else %>
+  Make sure the private key is [PKCS #8](https://tools.ietf.org/html/rfc5208) formatted and PEM encoded.
+<% end %>
 
 The self-signed certificate must be:
 
 - valid for one year
-- in [X.509](https://tools.ietf.org/html/rfc4158) format and PEM encoded with a `.crt` extension
+- in [X.509](https://tools.ietf.org/html/rfc4158) format and PEM encoded
 
 <%= partial "partials/details-tag-style" %>
 
@@ -19,7 +23,6 @@ The self-signed certificate must be:
  You can use [OpenSSL][openssl-github] to generate your keys and self-signed certificates. Most Linux distributions and Mac OS versions have OpenSSL installed.
 
 <% if component == "MSA" %>
-
 
 ```sh
 # generate your key and self-signed certificate

--- a/source/partials/_get-self-signed-certificates.erb
+++ b/source/partials/_get-self-signed-certificates.erb
@@ -1,6 +1,6 @@
 Use your preferred method to generate a new private key and self-signed certificate pair.
 
-Make sure the private key is [PKCS #8](https://tools.ietf.org/html/rfc5208) formatted with a `.pk8` extension.
+Make sure the private key is [PKCS #8](https://tools.ietf.org/html/rfc5208) formatted.
 
 The self-signed certificate must be:
 
@@ -18,12 +18,29 @@ The self-signed certificate must be:
   <div class="govuk-details__text">
  You can use [OpenSSL][openssl-github] to generate your keys and self-signed certificates. Most Linux distributions and Mac OS versions have OpenSSL installed.
 
+<% if component == "MSA" %>
+
+Generate your private key and self-signed certificate and convert the key to DER format:
+
+```sh
+# generate your key and self-signed certificate
+openssl req -x509 -newkey rsa:2048 -days 365 -nodes -sha256 \
+   -keyout <private-key>.key -out <certificate>.crt
+
+# convert your key to DER format (as required by MSA)
+openssl pkcs8 -topk8 -nocrypt \ 
+   -in <private-key>.key -out <private-key>.pk8 -outform DER
+```
+
+<% else %>
 Generate your private key and self-signed certificate:
 
 ```sh
 openssl req -x509 -newkey rsa:2048 -days 365 -nodes -sha256 \
-   -keyout <private-key>.pk8 -out <certificate>.crt
+   -keyout <private-key>.key -out <certificate>.crt
 ```
+
+<% end %>
 
 The terminal will prompt you for information. You must provide a `Common Name`. All other information is optional.
 

--- a/source/partials/_get-self-signed-certificates.erb
+++ b/source/partials/_get-self-signed-certificates.erb
@@ -20,7 +20,6 @@ The self-signed certificate must be:
 
 <% if component == "MSA" %>
 
-Generate your private key and self-signed certificate and convert the key to DER format:
 
 ```sh
 # generate your key and self-signed certificate

--- a/source/partials/_get-self-signed-certificates.erb
+++ b/source/partials/_get-self-signed-certificates.erb
@@ -26,7 +26,7 @@ The self-signed certificate must be:
 openssl req -x509 -newkey rsa:2048 -days 365 -nodes -sha256 \
    -keyout <private-key>.key -out <certificate>.crt
 
-# convert your key to DER format (as required by MSA)
+# convert your MSA key to use DER encoding
 openssl pkcs8 -topk8 -nocrypt \ 
    -in <private-key>.key -out <private-key>.pk8 -outform DER
 ```

--- a/source/rotating-your-keys-and-certificates/msa-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/msa-encryption/index.html.md.erb
@@ -17,7 +17,7 @@ You must update the certificates containing your MSA's public keys before they e
 
 ### Step 1. Create a new self-signed encryption certificate
 
-  <%= partial "partials/get-self-signed-certificates" %>
+  <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
 ### Step 2. Add the new encryption key and certificate to your MSA configuration
 

--- a/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
@@ -17,7 +17,7 @@ You must update the certificates containing your MSA's public keys before they e
 
 ### Step 1. Create a new self-signed signing certificate
 
-  <%= partial "partials/get-self-signed-certificates" %>
+  <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
 ### Step 2. Upload the new signing certificate
 

--- a/source/rotating-your-keys-and-certificates/service-provider-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-encryption/index.html.md.erb
@@ -19,7 +19,7 @@ If you're using the Verify Service Provider, [see how to update your Verify Serv
 
 ### Step 1. Create a new self-signed encryption certificate
 
-  <%= partial "partials/get-self-signed-certificates" %>
+  <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
 ### Step 2. Add the new encryption key and certificate
 

--- a/source/rotating-your-keys-and-certificates/service-provider-encryption/service-provider-encryption-no-dual-run/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-encryption/service-provider-encryption-no-dual-run/index.html.md.erb
@@ -19,7 +19,7 @@ If you're using the Verify Service Provider, [see how to update your Verify Serv
 
 ### Step 1. Create a new self-signed encryption certificate
 
-  <%= partial "partials/get-self-signed-certificates" %>
+  <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
 ### Step 2. Upload the new encryption certificate
 

--- a/source/rotating-your-keys-and-certificates/service-provider-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/service-provider-signing/index.html.md.erb
@@ -17,7 +17,7 @@ If you're using the Verify Service Provider, [see how to update your Verify Serv
 
 ### Step 1. Create a new self-signed signing certificate
 
-  <%= partial "partials/get-self-signed-certificates" %>
+  <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
 ### Step 2. Upload the new signing certificate
 

--- a/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/vsp-encryption/index.html.md.erb
@@ -17,7 +17,7 @@ If you're using a custom service provider, [go to the section about updating ser
 
 ### Step 1. Create a new self-signed encryption certificate
 
-  <%= partial "partials/get-self-signed-certificates" %>
+  <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
 ### Step 2. Add the new encryption key to the VSP configuration
 

--- a/source/rotating-your-keys-and-certificates/vsp-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/vsp-signing/index.html.md.erb
@@ -17,7 +17,7 @@ If you're using a custom service provider, [go to the section about updating ser
 
 ### Step 1. Create a new self-signed signing certificate
 
-  <%= partial "partials/get-self-signed-certificates" %>
+  <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
 ### Step 2. Upload the new signing certificate
 


### PR DESCRIPTION
MSA expects the key in binary DER format, so for MSA rotations there's an extra step required.