### PR TITLE
Swap step order for cert uploading and config changing - MSA signing

### DIFF
--- a/source/partials/_add-new-key.erb
+++ b/source/partials/_add-new-key.erb
@@ -71,8 +71,6 @@ signingKeys:
 
 Restarting the MSA publishes the new signing certificate to the MSA's metadata. The service provider you’re using reads this metadata and uses the MSA's signing certificate to trust assertions signed by the MSA.
 
-If you’re using the VSP, wait for it to load the MSA metadata. The VSP periodically refreshes its metadata and will log when it has finished. Once it loads the new metadata, the VSP trusts assertions signed with the new MSA signing key.
-
 <% end %>
 
 

--- a/source/partials/_remove-old-key.erb
+++ b/source/partials/_remove-old-key.erb
@@ -6,28 +6,26 @@ The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub is now us
 
 <%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before removing the old encryption key.') %>
 
-<% if component == "VSP" %>
+  <% if component == "VSP" %>
 
-To remove the old encryption key from the <%= component %> configuration:
+    To remove the old encryption key from the <%= component %> configuration:
 
-1. Remove the key in `samlPrimaryEncryptionKey` and replace it with the key from `samlSecondaryEncryptionKey`.
-1. Leave `samlSecondaryEncryptionKey` empty for the next update.
-1. Restart the <%= component %> to implement the configuration changes.
+    1. Remove the key in `samlPrimaryEncryptionKey` and replace it with the key from `samlSecondaryEncryptionKey`.
+    1. Leave `samlSecondaryEncryptionKey` empty for the next update.
+    1. Restart the <%= component %> to implement the configuration changes.
 
-<% end %>
-
-
-<% if component == "MSA" %>
-
-Delete the old encryption key and certificate from your <%= component %>'s configuration.
-
-Remember to restart the <%= component %> to implement the configuration changes.
-
-While both old and new keys are in use, you may see error messages in the logs with the description `Unwrapping failed`. These messages appear because the MSA attempts to decrypt the SAML message using each key in turn. You can safely ignore these messages. However, do not ignore any other error messages related to SAML decryption.
-
-<% end %>
+  <% end %>
 
 
+  <% if component == "MSA" %>
+
+    Delete the old encryption key and certificate from your <%= component %>'s configuration.
+
+    Remember to restart the <%= component %> to implement the configuration changes.
+
+    While both old and new keys are in use, you may see error messages in the logs with the description `Unwrapping failed`. These messages appear because the MSA attempts to decrypt the SAML message using each key in turn. You can safely ignore these messages. However, do not ignore any other error messages related to SAML decryption.
+
+  <% end %>
 
 Once you've removed the old <%= type %> key, your <%= component %> only uses the new encryption key to decrypt messages from GOV.UK Verify Hub.
 
@@ -36,18 +34,23 @@ Once you've removed the old <%= type %> key, your <%= component %> only uses the
 
 <% if component == "MSA" and type == "signing" %>
 
-The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub now trusts messages signed with your new <%= component %> signing key. This means you can replace the old signing key from your <%= component %> configuration.
+  Before deleting the old key and certificate make sure your service provider
 
-<newline>
+  * you've received deployment confirmation from the GOV.UK Verify Team
+  * your service provider is using your new MSA <%= type %> certificate
 
-<%= warning_text('Wait for the deployment confirmation e-mail from the GOV.UK Verify Team before deleting the old signing key.') %>
+  If you’re using the VSP, you can check its logs to confirm the VSP refreshed its metadata. Once it has loaded the new MSA metadata, the VSP is using your new MSA <%= type %> certificate to trust messages from your MSA.
 
-To remove the old signing key from the MSA configuration:
+  The e-mail from the GOV.UK Verify team confirms that GOV.UK Verify Hub is using your new MSA <%= type %> certificate to trust messages signed with your new <%= component %> signing key. This means you can replace the old signing key from your <%= component %> configuration.
 
-1. Delete the `signingKeys.primary` section.
-1. Rename `signingKeys.secondary` to `signingKeys.primary`. The MSA now signs the assertions with the new  key.
-1. Restart the MSA to update its metadata to contain only the new signing certificate.
+  <%= warning_text('Make sure both your service provider and the GOV.UK Verify Hub are using the new signing certificate before deleting the old signing key.') %>
 
-Your service provider now trusts assertions signed with your new <%= component %> signing key.
+  To remove the old signing key from the MSA configuration:
+
+  1. Delete the `signingKeys.primary` section.
+  1. Rename `signingKeys.secondary` to `signingKeys.primary`. The MSA now signs the assertions with the new  key.
+  1. Restart the MSA to update its metadata to contain only the new signing certificate.
+
+  Your service provider now trusts assertions signed with your new <%= component %> signing key.
 
 <% end %>

--- a/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
+++ b/source/rotating-your-keys-and-certificates/msa-signing/index.html.md.erb
@@ -19,13 +19,13 @@ You must update the certificates containing your MSA's public keys before they e
 
   <%= partial "partials/get-self-signed-certificates", locals: locals %>
 
-### Step 2. Upload the new signing certificate
-
-  <%= partial "partials/upload-new-certificate", locals: locals %>
-
-### Step 3. Add the new signing key and certificate to your MSA configuration
+### Step 2. Add the new signing key and certificate to your MSA configuration
 
   <%= partial "partials/add-new-key", locals: locals %>
+
+### Step 3. Upload the new signing certificate
+
+  <%= partial "partials/upload-new-certificate", locals: locals %>
 
 ### Step 4. Delete the old MSA signing key and certificate
 


### PR DESCRIPTION
## What

The old order is:
2. upload new cert
3. change MSA config

The new order is:
2. change MSA config
3. upload new cert

The swap does not break anything, the cert uploading and config changing
can happen in any order.

This commit also:
* adds indenting to ERB conditionals
* moves the paragraph about (V)SP picking up new MSA metadata to the
beginning of the delete key step, where the user is more likely to read
it.

## Why

We are making the change because then the steps would be similar to the
MSA encryption flow and users could do both at the same time. This means
they could get away with 4 deployments rather than 2. This came out of
the private beta testing sessions.