### PR TITLE
Update accessibility statement

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -14,7 +14,8 @@ header_links:
   Support: https://www.verify.service.gov.uk/support/
 # Links to show in the page footer
 footer_links:
-  Accessibility: /accessibility-statement
+  GOV.UK Verify Website Accessibility: https://www.verify.service.gov.uk/accessibility/
+  Technical Documentation Accessibility: /accessibility.html
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id: UA-26179049-26

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,7 +15,7 @@ header_links:
 # Links to show in the page footer
 footer_links:
   GOV.UK Verify Website Accessibility: https://www.verify.service.gov.uk/accessibility/
-  Technical Documentation Accessibility: /accessibility.html
+  Technical Documentation Accessibility: /accessibility-statement
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id: UA-26179049-26

--- a/source/accessibility-statement/index.html.md.erb
+++ b/source/accessibility-statement/index.html.md.erb
@@ -8,7 +8,7 @@ hide_in_navigation: true
 
 # Accessibility statement for GOV.UK Verify technical documentation
 
-This accessibility statement applies to the GOV.UK Verify technical documentation at [https://docs.verify.service.gov.uk/](https://docs.verify.service.gov.uk/).
+This accessibility statement applies to the GOV.UK Verify technical documentation at [https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation](https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation).
 
 This website is run by the GOV.UK Verify team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
 

--- a/source/accessibility-statement/index.html.md.erb
+++ b/source/accessibility-statement/index.html.md.erb
@@ -1,30 +1,34 @@
 ---
-title: Accessibility
+title: Accessibility statement for GOV.UK Verify technical documentation
 weight: 999
+last_reviewed_on: 2020-09-21
+review_in: 6 months
 hide_in_navigation: true
 ---
-# Accessibility
-## Accessibility statement for GOV.UK Verify technical documentation
 
-This website is run by the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+# Accessibility statement for GOV.UK Verify technical documentation
 
-- change colours, contrast levels and fonts
-- zoom in up to 300% without the text spilling off the screen
-- navigate most of the website using just a keyboard
-- navigate most of the website using speech recognition software
-- listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+This accessibility statement applies to the GOV.UK Verify technical documentation at [https://docs.verify.service.gov.uk/](https://docs.verify.service.gov.uk/).
+
+This website is run by the GOV.UK Verify team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without problems
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
 
 We’ve also made the website text as simple as possible to understand.
 
 [AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
 
-
 ### How accessible this website is
 
-We know some parts of this website are not fully accessible:
+We know some parts of this website are not fully accessible for the following reasons:
 
 - there are images which contain text, and a text-only alternative is not available
 - the colour contrast is not high enough for some of the images
+- there are issues caused by our Technical Documentation Template
 
 ### What to do if you cannot access parts of this website
 
@@ -56,30 +60,33 @@ There are some images which contain text, and a text-only alternative is not ava
 
 The colour contrast ratio for some of the images is less than 3:1. This fails WCAG 2.1 success criterion [1.4.11 (non-text contrast)](https://www.w3.org/WAI/WCAG21/quickref/#non-text-contrast).
 
-We will make all these elements fully accessible by September 2020.
+There are parts of this documentation that are not accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
 
 ## How we tested this website
 
-We last tested this website for accessibility issues in September 2019.
+We last tested this website for accessibility issues in August 2020.
 
 We used manual and automated tests to look for issues such as:
 
 - lack of keyboard accessibility
 - link text that’s not descriptive
+- non-unique or non-hierarchical headings
+- italics, bold or block capital formatting
+- inaccessible formatting in general
+- inaccessible language
+- inaccessible diagrams or images
 - lack of colour contrast for text, important graphics and controls
 - images not having meaningful alt text
-- lack of subtitles for videos
 - problems when using assistive technologies such as screen readers and screen magnifiers
 
 ## What we’re doing to improve accessibility
 
-We will make changes to this website to make it fully accessible.
+We plan to fix the accessibility issues in the content by the end of 2020.
 
-We will:
+## Preparation of this accessibility statement
 
-- provide text alternatives for any images
-- increase the colour contrast ratio for all images to 3:1 or higher
+We plan to fix the issues with the Technical Documentation Template by the end of 2020.
 
-We will make these changes by September 2020.
+This statement was prepared on 21 September 2020. It was last updated on 21 September 2020.
 
-This statement was prepared on 20 September 2019. It was last updated on 15 November 2019.
+This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.


### PR DESCRIPTION
### Context
The deadline for publishing an accessibility statement is 23 September 2020. The GOV.UK Verify technical documentation already has a statement published. This is separate to the statement on the tech doc template itself, which is being handled as part of a separate project.

### Changes proposed in this pull request
Update the accessibility statement for tech docs with information from the August 2020 accessibility audit. Include a link in the bottom navigation to the Verify website accessibility statement. 