### PR TITLE
Update fix date for accessibility issues

### DIFF
--- a/source/accessibility-statement/index.html.md.erb
+++ b/source/accessibility-statement/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Accessibility statement for GOV.UK Verify technical documentation
 weight: 999
-last_reviewed_on: 2020-09-21
+last_reviewed_on: 2020-12-21
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -81,12 +81,12 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the accessibility issues in the content by the end of 2020.
+We plan to fix the accessibility issues in the content by the end of March 2021.
 
 ## Preparation of this accessibility statement
 
-We plan to fix the issues with the Technical Documentation Template by the end of 2020.
+We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
 
-This statement was prepared on 21 September 2020. It was last updated on 21 September 2020.
+This statement was prepared on 21 September 2020. It was last updated on 21 December 2020.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.


### PR DESCRIPTION
Updated the date for fixing the Tech Docs Template accessibility issues from “end of December 2020” to “end of March 2021”. As a result of resourcing pressures and re-prioritisation this year, it’s taking longer than we hoped to arrange developer and designer resources to fix the accessibility issues.