### PR TITLE
HUB-729 Add diagram steps to improve accessibility

### DIFF
--- a/source/accessibility-statement/index.html.md.erb
+++ b/source/accessibility-statement/index.html.md.erb
@@ -85,6 +85,6 @@ We plan to fix the accessibility issues in the content by the end of March 2021.
 
 We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
 
-This statement was prepared on 21 September 2020. It was last updated on 22 January 2020.
+This statement was prepared on 21 September 2020. It was last updated on 22 January 2021.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.

--- a/source/accessibility-statement/index.html.md.erb
+++ b/source/accessibility-statement/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Accessibility statement for GOV.UK Verify technical documentation
 weight: 999
-last_reviewed_on: 2020-12-21
+last_reviewed_on: 2021-01-22
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -26,8 +26,6 @@ We’ve also made the website text as simple as possible to understand.
 
 We know some parts of this website are not fully accessible for the following reasons:
 
-- there are images which contain text, and a text-only alternative is not available
-- the colour contrast is not high enough for some of the images
 - there are issues caused by our Technical Documentation Template
 
 ### What to do if you cannot access parts of this website
@@ -87,6 +85,6 @@ We plan to fix the accessibility issues in the content by the end of March 2021.
 
 We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
 
-This statement was prepared on 21 September 2020. It was last updated on 21 December 2020.
+This statement was prepared on 21 September 2020. It was last updated on 22 January 2020.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.

--- a/source/get-started/set-up-successful-verification-journey/index.html.md.erb
+++ b/source/get-started/set-up-successful-verification-journey/index.html.md.erb
@@ -38,6 +38,13 @@ Once a user starts a GOV.UK Verify journey from their browser, your service must
 
 ![](/images/vsp-request-sequence-diagram.svg)
 
+1. Your user starts the journey from their browser.
+1. Your service sends a request to the VSP to generate a SAML authentication request.
+1. The VSP returns a SAML authentication request to your service.
+1. Your service sends an HTML form with the authentication request to your user’s browser.
+1. Your user submits the HTML form in their browser to the testing service.
+
+
 ### Generate an authentication request
 
 Make an HTTP POST request to the VSP's `/generate-request` endpoint to generate an authentication request message:
@@ -122,6 +129,12 @@ If the status is not `PASSED`, you may need to restart the VSP using the `develo
 Your service needs to be able to receive an HTML form containing the SAML response. The testing service sends the form through the browser. After receiving the form, your service translates the SAML response into JSON using the VSP. Depending on the scenario in the SAML message, your service should offer appropriate messaging to help the user continue.
 
 ![](/images/vsp-response-sequence-diagram.svg)
+
+1. The testing service sends a SAML response in an HTML form to your user’s browser.
+1. Your user submits the HTML form in their browser to your service.
+1. Your service sends a request to the VSP to translate the SAML response into JSON.
+1. The VSP returns the JSON to your service.
+1. Your service shows a result page in your user’s browser.
 
 
 ### Run the IDENTITY_VERIFIED response scenario

--- a/source/get-started/set-up-successful-verification-journey/index.html.md.erb
+++ b/source/get-started/set-up-successful-verification-journey/index.html.md.erb
@@ -44,7 +44,6 @@ Once a user starts a GOV.UK Verify journey from their browser, your service must
 1. Your service sends an HTML form with the authentication request to your user’s browser.
 1. Your user submits the HTML form in their browser to the testing service.
 
-
 ### Generate an authentication request
 
 Make an HTTP POST request to the VSP's `/generate-request` endpoint to generate an authentication request message:
@@ -135,7 +134,6 @@ Your service needs to be able to receive an HTML form containing the SAML respon
 1. Your service sends a request to the VSP to translate the SAML response into JSON.
 1. The VSP returns the JSON to your service.
 1. Your service shows a result page in your user’s browser.
-
 
 ### Run the IDENTITY_VERIFIED response scenario
 


### PR DESCRIPTION
Context: Two images in the Verify tech docs do not have an equivalent process explanation in the text, which fails accessibility requirements. This PR adds steps to describe the processes in the images and also updates the tech docs accessibility statement to remove image related failures.