### PR TITLE
HUB-796: Bump tech-docs Gem to 2.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/alphagov/middleman-search.git
-  revision: d13d7c42ac0a48fcfb3d37c514f95674406405e1
+  revision: f7addd7448cf49d3176022190b0aa1827c89fd83
   specs:
-    middleman-search-gds (0.11.0a)
+    middleman-search-gds (0.11.1)
       execjs (~> 2.6)
       middleman-core (>= 3.2)
       nokogiri (~> 1.6)
@@ -10,7 +10,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.7.2)
+    activesupport (5.2.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -19,7 +19,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (9.8.6.5)
       execjs
-    backports (3.15.0)
+    backports (3.20.2)
     chronic (0.10.2)
     chunky_png (1.4.0)
     coffee-script (2.4.1)
@@ -40,9 +40,9 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.8)
     contracts (0.13.0)
-    dotenv (2.7.5)
+    dotenv (2.7.6)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -50,9 +50,9 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     fast_blank (1.0.0)
-    fastimage (2.1.7)
-    ffi (1.11.3)
-    govuk_tech_docs (2.2.1)
+    fastimage (2.2.3)
+    ffi (1.15.0)
+    govuk_tech_docs (2.2.2)
       chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.10.0)
@@ -73,27 +73,28 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (1.17.0)
+    kramdown (2.3.1)
+      rexml
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.2)
-    middleman (4.3.5)
+    middleman (4.3.11)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
-      kramdown (~> 1.2)
-      middleman-cli (= 4.3.5)
-      middleman-core (= 4.3.5)
+      kramdown (>= 2.3.0)
+      middleman-cli (= 4.3.11)
+      middleman-core (= 4.3.11)
     middleman-autoprefixer (2.10.1)
       autoprefixer-rails (~> 9.1)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.3.5)
+    middleman-cli (4.3.11)
       thor (>= 0.17.0, < 2.0)
     middleman-compass (4.0.1)
       compass (>= 1.0.0, < 2.0.0)
       middleman-core (>= 4.0.0)
-    middleman-core (4.3.5)
-      activesupport (>= 4.2, < 5.1)
+    middleman-core (4.3.11)
+      activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       backports (~> 3.6)
       bundler
@@ -125,11 +126,10 @@ GEM
     middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
-    mini_portile2 (2.4.0)
-    minitest (5.13.0)
+    minitest (5.14.4)
     multi_json (1.15.0)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.2-x86_64-darwin)
+      racc (~> 1.4)
     openapi3_parser (0.9.0)
       commonmarker (~> 0.17)
       psych (~> 3.1)
@@ -139,21 +139,23 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
-    parallel (1.19.1)
+    parallel (1.20.1)
     psych (3.3.1)
-    public_suffix (4.0.1)
-    rack (2.0.8)
+    public_suffix (4.0.6)
+    racc (1.5.2)
+    rack (2.2.3)
     rack-livereload (0.3.17)
       rack
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
+    rexml (3.2.4)
     rouge (3.26.0)
     ruby-enum (0.9.0)
       i18n
     sass (3.4.25)
-    sassc (2.2.1)
+    sassc (2.4.0)
       ffi (~> 1.9)
     servolux (0.13.0)
     sprockets (4.0.2)
@@ -163,13 +165,13 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.5)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   govuk_tech_docs (~> 2.2)
@@ -178,4 +180,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.15


### PR DESCRIPTION
It includes another accessibility fix.