### PR TITLE
HUB-963: Remove ida support email from public pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,7 +2,7 @@ require 'govuk_tech_docs'
 
 GovukTechDocs::SourceUrls.class_eval do
   def report_issue_url
-    'mailto:idasupport@digital.cabinet-office.gov.uk?subject=Feedback%20for%20the%20GOV.UK%20Verify%20technical%20documentation'
+    'https://www.signin.service.gov.uk/feedback?'
   end
 end
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,7 +9,6 @@ phase:
 
 # Links to show on right-hand-side of header
 header_links:
-  Connecting: https://www.verify.service.gov.uk/connecting/
   Documentation: /
   Support: https://www.verify.service.gov.uk/support/
 # Links to show in the page footer

--- a/source/accessibility-statement/index.html.md.erb
+++ b/source/accessibility-statement/index.html.md.erb
@@ -28,13 +28,13 @@ This website is fully compliant with the [Web Content Accessibility Guidelines v
 
 ### What to do if you cannot access parts of this website
 
-If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, please contact [idasupport@digital.cabinet-office.gov.uk](mailto:idasupport@digital.cabinet-office.gov.uk) with details of your request.
+If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, please use the <a rel="external" href="https://www.signin.service.gov.uk/feedback?" class="govuk-link">GOV.UK Verify user support form</a> to provide details of your request.
 
 We’ll aim to reply within 2 working days.
 
 ### Reporting accessibility problems with this website
 
-We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact [idasupport@digital.cabinet-office.gov.uk](mailto:idasupport@digital.cabinet-office.gov.uk).
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please please use the <a rel="external" href="https://www.signin.service.gov.uk/feedback?" class="govuk-link">GOV.UK Verify user support form</a> to get help and give feedback on GOV.UK Verify.
 
 ### Enforcement procedure
 

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -7,9 +7,6 @@
 [vsp-guide-response]: /get-started/set-up-successful-verification-journey/#handle-a-response
 
 [vsp-guide-failure]: /get-started/handling-failure-scenarios
-[error-page-not-verified]: https://www.verify.service.gov.uk/design-your-service#if-a-user-cannot-be-verified
-
-[loa]: https://www.verify.service.gov.uk/understand-levels-of-assurance/
 
 [manage-certs]: https://www.admin.verify.service.gov.uk
 [openssl-github]: https://github.com/openssl/openssl


### PR DESCRIPTION
Use the feedback form instead to let people contact us.

- Remove dead links (see https://github.com/alphagov/verify-product-page/pull/67)
- Udpate accessibility statement to use the feedback form instead of email